### PR TITLE
[Mark] Fix raster image data problems

### DIFF
--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -707,7 +707,8 @@ std::vector<float> DataSource::_getRasterImageData(double xMin, double xMax, dou
     int prepareCols = iub - ilb;
     int prepareRows = mip;
     int area = prepareCols * prepareRows;
-    std::vector<float> rawData(nCols), prepareArea(area);
+    float rawData;
+    std::vector<float> prepareArea(area);
     int nextRowToReadIn = jlb;
 
     auto updateRows = [&]() -> void {
@@ -730,7 +731,7 @@ std::vector<float> DataSource::_getRasterImageData(double xMin, double xMax, dou
 
         // Calculate the mean of each block (mip X mip)
         for (int i = ilb; i < ilb + nCols; i++) {
-            rawData[i] = 0;
+            rawData = 0;
             int elems = mip * mip;
             float denominator = elems;
             for (int e = 0; e < elems; e++) {
@@ -738,14 +739,14 @@ std::vector<float> DataSource::_getRasterImageData(double xMin, double xMax, dou
                 int col = e % mip;
                 int index = (row * prepareCols + col + i * mip) % area;
                 if (std::isfinite(prepareArea[index])) {
-                    rawData[i] += prepareArea[index];
+                    rawData += prepareArea[index];
                 } else {
                     denominator -= 1;
                 }
             }
             // set the NaN type of the pixel as the minimum of the other finite pixel values
-            rawData[i] = (denominator < 1 ? minIntensity : rawData[i] / denominator);
-            results.push_back(rawData[i]);
+            rawData = (denominator < 1 ? minIntensity : rawData / denominator);
+            results.push_back(rawData);
         }
         nextRowToReadIn += update;
     };

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -697,14 +697,14 @@ std::vector<float> DataSource::_getRasterImageData(double xMin, double xMax, dou
 
     std::vector<float> results;
     int ilb = xMin;
-    int iub = xMax - 1;
+    int iub = xMax;
     int jlb = yMin;
-    int jub = yMax - 1;
+    int jub = yMax;
 
-    int nRows = (jub - jlb + 1) / mip;
-    int nCols = (iub - ilb + 1) / mip;
+    int nRows = (jub - jlb) / mip;
+    int nCols = (iub - ilb) / mip;
 
-    int prepareCols = iub - ilb + 1;
+    int prepareCols = iub - ilb;
     int prepareRows = mip;
     int area = prepareCols * prepareRows;
     std::vector<float> rawData(nCols), prepareArea(area);
@@ -729,7 +729,7 @@ std::vector<float> DataSource::_getRasterImageData(double xMin, double xMax, dou
         });
 
         // Calculate the mean of each block (mip X mip)
-        for (int i = ilb; i < nCols; i++) {
+        for (int i = ilb; i < ilb + nCols; i++) {
             rawData[i] = 0;
             int elems = mip * mip;
             float denominator = elems;
@@ -751,7 +751,7 @@ std::vector<float> DataSource::_getRasterImageData(double xMin, double xMax, dou
     };
 
     // scan the raw data for with rows for down sampling
-    for (int j = jlb; j < nRows; j++) {
+    for (int j = jlb; j < jlb + nRows; j++) {
         updateRows();
     }
 

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -476,12 +476,18 @@ void NewServerConnector::onBinaryMessage(char* message, size_t length){
         int x_max = viewSetting.image_bounds().x_max();
         int y_min = viewSetting.image_bounds().y_min();
         int y_max = viewSetting.image_bounds().y_max();
-        qDebug() << "get the x-pixel-coordinate range: [x_min, x_max]= [" << x_min << "," << x_max << "]";
-        qDebug() << "get the y-pixel-coordinate range: [y_min, y_max]= [" << y_min << "," << y_max << "]";
+        int W = (x_max - x_min) / mip;
+        int H = (y_max - y_min) / mip;
+        qDebug() << "get the x-pixel-coordinate range: [x_min, x_max]= [" << x_min << "," << x_max << "]"
+                 << "--> W=" << W;
+        qDebug() << "get the y-pixel-coordinate range: [y_min, y_max]= [" << y_min << "," << y_max << "]"
+                 << "--> H=" << H;
 
         // get the raster image raw data
         std::vector<float> imageData = controller->getRasterImageData(x_min, x_max, y_min, y_max, mip,
             m_minIntensity, frameLow, frameHigh, stokeFrame);
+        qDebug() << "number of the raw data sent L=" << imageData.size() << ", WxH=" << W * H
+                 << ", Difference:" << (W * H - imageData.size());
 
         // add the RasterImageData message
         CARTA::ImageBounds* imgBounds = new CARTA::ImageBounds();

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -364,7 +364,15 @@ void NewServerConnector::onBinaryMessage(char* message, size_t length){
 
         CARTA::OpenFile openFile;
         openFile.ParseFromArray(message + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, length - EVENT_NAME_LENGTH - EVENT_ID_LENGTH);
-        controller->addData(QString::fromStdString(openFile.directory()) + "/" + QString::fromStdString(openFile.file()), &success);
+
+        QString fileDir = QString::fromStdString(openFile.directory());
+        QString fileName = QString::fromStdString(openFile.file());
+        if (!QDir(fileDir).exists()) {
+            qWarning() << "File directory doesn't exist! (" << fileDir << ")";
+            return;
+        }
+
+        controller->addData(fileDir + "/" + fileName, &success);
 
         if (success) {
             m_changeImage = true;

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -447,8 +447,11 @@ void NewServerConnector::onBinaryMessage(char* message, size_t length){
             // add RegionHistogramData message
             std::shared_ptr<CARTA::RegionHistogramData> region_histogram_data(new CARTA::RegionHistogramData());
             region_histogram_data->set_file_id(viewSetting.file_id());
+
+            // If the histograms correspond to the entire current 2D image, the region ID has a value of -1.
             region_histogram_data->set_region_id(-1);
-            region_histogram_data->set_stokes(0);
+
+            region_histogram_data->set_stokes(stokeFrame);
 
             CARTA::Histogram* histogram = region_histogram_data->add_histograms();
             histogram->set_channel(frameLow);

--- a/carta/cpp/desktop/NewServerConnector.h
+++ b/carta/cpp/desktop/NewServerConnector.h
@@ -126,7 +126,11 @@ protected:
 private:
     bool m_changeImage = false;
     double m_minIntensity;
-
+    int m_xMin = 0;
+    int m_xMax = 0;
+    int m_yMin = 0;
+    int m_yMax = 0;
+    int m_mip = 0;
 };
 
 


### PR DESCRIPTION
This PR fixes the following problems:

1. The inconsistency of the image viewer bounds on the frontend with respect to the raw data size that provided by the backend.
2. The crash problem that caused by the incorrect memory allocation while calculating the downsampling raw data.
3. The crash problem that caused by the incomplete message (image file directory) from the frontend.  It sometimes happens while we double clip the image file name in order to open it.