### PR TITLE
Sean/add file info

### DIFF
--- a/carta/cpp/desktop/FitsHeaderExtractor.cpp
+++ b/carta/cpp/desktop/FitsHeaderExtractor.cpp
@@ -1,0 +1,243 @@
+/**
+ * Code that generates a fits header from ImageInterface using casacore.
+ **/
+
+#include "FitsHeaderExtractor.h"
+#include "plugins/CasaImageLoader/CCImage.h"
+
+#include <casacore/images/Images/ImageFITSConverter.h>
+#include <casacore/fits/FITS/fitsio.h>
+#include <casacore/fits/FITS/hdu.h>
+#include <casacore/fits/FITS/FITSDateUtil.h>
+#include <casacore/fits/FITS/FITSKeywordUtil.h>
+#include <casacore/fits/FITS/FITSHistoryUtil.h>
+#include <casacore/casa/Quanta/MVTime.h>
+#include <casacore/casa/Containers/Record.h>
+#include <casacore/casa/Arrays/Matrix.h>
+#include <casacore/coordinates/Coordinates/LinearCoordinate.h>
+#include <casacore/images/Images/ImageInterface.h>
+
+#include "CartaLib/UtilCASA.h"
+
+void FitsLine::_parse(QString &key, QString &value, QString &comment) {
+    // key is the first 8 characters (trimmed)
+    key = _raw.left(8).trimmed();
+    // by default, value & comment are empty
+    value = comment = QString();
+    // if there is no equal sign present, return the default values for value/comment, which is empty
+    if( _raw.mid( 8, 2).trimmed() != "=") return;
+    // find the start/end of the value
+    //   start = first non-white character
+    //   end   = last character of the value (if string, it's the closing quote, otherwise it's the last non-space
+    int vStart = 10, vEnd = -1;
+    while( _raw[vStart].isSpace()) { vStart ++; if( vStart >= 80) { vStart = -1; break; }}
+    if( vStart == -1) // entire line is empty after the '='
+        return;
+    if( _raw[vStart] != '\'') { // it's an unquoted value
+        // non-string value, find the end
+        vEnd = _raw.indexOf( '/', vStart + 1); if( vEnd != -1) vEnd --; else vEnd = 79;
+        //            vEnd = vStart + 1;
+        //            while( ! _raw[vEnd].isSpace()) { if( vEnd >= 80) break; else vEnd ++; }
+        //            vEnd --;
+    } else { // it's s quoted string
+        // temporarily remove all occurrences of double single-quotes and then find the next single quote
+        QString tmp = _raw; for(int i=0;i<=vStart;i++){tmp[i]=' ';} tmp.replace( "''", "..");
+        vEnd = tmp.indexOf( '\'', vStart + 1);
+        if( vEnd == -1) // we have an unterminated string here
+            throw QString( "Unterminated string in header for %1").arg(key);
+    }
+    // now that we know start/end, get the value
+    value = _raw.mid( vStart, vEnd - vStart + 1).trimmed();
+
+    // if this was a string value, get rid of the double single-quotes permanently, and remove the surrounding quotes too
+    //if( value[0] == '\'') value = value.mid( 1, value.length()-2).replace( "''", "'");
+
+    // is there a comment?
+    comment = _raw.mid( vEnd + 1).trimmed();
+    if( ! comment.isEmpty()) {
+        if( comment[0] != '/')
+            throw ("Syntax error in header: " + _raw.trimmed());
+        else
+            comment.remove(0,1);
+    }
+}
+
+QString FitsLine::getline(QString & key, QString & value)
+{
+    QString NewKeyStr = key.append(QString(8 - key.length(),' '));
+    QString NewHeader = QString("%1= %2 /").arg(NewKeyStr).arg(value);
+    return NewHeader.append(QString(80 - NewHeader.length(),' '));
+}
+
+FitsHeaderExtractor::FitsHeaderExtractor()
+{ }
+
+FitsHeaderExtractor::~FitsHeaderExtractor()
+{ }
+
+void
+FitsHeaderExtractor::setInput( Carta::Lib::Image::ImageInterface::SharedPtr image )
+{
+    m_cartaImage = image;
+}
+
+QStringList
+FitsHeaderExtractor::getHeader()
+{
+    m_errors.clear();
+    if ( ! m_cartaImage ) {
+        m_errors << "Input is NULL";
+        return QStringList();
+    }
+
+    QStringList result;
+
+    // was this created using CasaImageLoader plugin?
+    CCImageBase * base = dynamic_cast < CCImageBase * > ( & * m_cartaImage );
+    if ( base ) {
+        casacore::LatticeBase * latticeBase = base-> getCasaImage();
+        if ( latticeBase ) {
+
+            // casacore's fits parser
+            result = _CasaFitsConverter( latticeBase );
+        }
+        else {
+            m_errors << "Cannot produce FITS header for this image because"
+                     << "I have no idea where this image came from.";
+        }
+    }
+
+    return result;
+} // getHeader
+
+QStringList
+FitsHeaderExtractor::getErrors()
+{
+    return m_errors;
+}
+
+// Most of the code here was extracted from ImageFITS2Converter.cc from casaCore-1.7.0 source
+// tree. There are probably unused pieces of code/weird comments,etc...
+/// \todo clean up the code below
+QStringList
+FitsHeaderExtractor::_CasaFitsConverter( casacore::LatticeBase * lbase )
+{
+    // can we get float image interface ?
+    casacore::ImageInterface < casacore::Float > * fii = nullptr;
+    #ifndef Q_OS_MAC
+        fii = dynamic_cast < casacore::ImageInterface < casacore::Float > * > ( lbase );
+    #else
+        fii = static_cast < casacore::ImageInterface < casacore::Float > * > ( lbase );
+    #endif
+
+    if ( ! fii ) {
+        m_errors << "Could not convert base to float image";
+        return QStringList();
+    }
+
+    // alias image to be reference to the image, since the original code used a reference
+    // rather than a pointer and I'm too lazy to convert everything to pointers :)
+    casacore::ImageInterface < casacore::Float > & image = * fii;
+
+    using namespace casacore;
+
+    QStringList errors;
+    bool preferVelocity = true;
+    bool opticalVelocity = true;
+    float minPix = 1.0;
+    float maxPix = - 1.0;
+    int BITPIX = - 32;
+
+    // I'm leaving the following in as constansts for the moment,
+    // in case we ever decide to do something fancier. They used to be configurable parameters
+    // in casacore
+    const bool stokesLast = false;
+    const bool degenerateLast = false;
+    const bool preferWavelength = false;
+    const bool airWavelength = false;
+
+    const bool verbose = false;
+    const bool primHead = true;
+    const bool allowAppend = true;
+    const bool history = false;
+
+    String originStr = String();
+    String errorString;
+    ImageFITSHeaderInfo fhi;
+
+    casa_mutex.lock();
+    bool isok = ImageFITSConverter::ImageHeaderToFITS (errorString, fhi, image,
+                                                       preferVelocity, opticalVelocity,
+                                                       BITPIX, minPix, maxPix,
+                                                       degenerateLast, verbose,
+                                                       stokesLast, preferWavelength,
+                                                       airWavelength,
+                                                       primHead, allowAppend,
+                                                       originStr, history);
+    casa_mutex.unlock();
+
+    if(!isok)
+    {
+        m_errors << errorString.c_str();
+        return QStringList();
+    }
+
+    // add END keyword
+    fhi.kw.end();
+
+    FitsKeyCardTranslator m_kc;
+
+    // the translator needs a buffer of 2880 bytes...
+    QByteArray buff( 2880, 'X' );
+
+    QStringList result;
+    fhi.kw.first();
+    fhi.kw.next();
+    while ( true ) {
+        bool done = ! m_kc.build( buff.data(), fhi.kw );
+        QString allStr( buff );
+        for ( int i = 0 ; i < 2880 ; i += 80 ) {
+            QString raw = allStr.mid( i, 80 );
+            QString line = _FITSKeyWordParser(raw);
+            if( !line.isEmpty() )
+            {
+                result << line;
+            }
+            if ( line.startsWith( "END" ) && line.simplified() == "END" ) {
+                done = true;
+                break;
+            }
+        }
+        if ( done ) {
+            break;
+        }
+    }
+
+    return result;
+} // tryCasaCoreFitsConverter
+
+QString FitsHeaderExtractor::_FITSKeyWordParser(QString _raw)
+{
+    QString lineStr;
+    QString key = FitsLine(_raw).key();
+    QString val = FitsLine(_raw).value();
+    if(!key.isEmpty() &&
+            QString::compare(key, "ORIGIN", Qt::CaseInsensitive) &&
+            QString::compare(key, "HISTORY", Qt::CaseInsensitive) &&
+            QString::compare(key, "COMMENT", Qt::CaseInsensitive))
+    {
+        // in general case
+        lineStr = _raw;
+
+        // Known issue: CASAImage does not follow FIT-WCS standard
+        // replace PC%2_%2 to PC%1_%1
+        if( key.contains(QRegExp("PC[0-9]{2}_[0-9]{2}")) )
+        {
+            QString NewKey = QString("PC%1_%2").arg(key.at(3)).arg(key.at(6));
+            lineStr = FitsLine::getline(NewKey, val);
+        };
+
+    }
+
+    return lineStr;
+}

--- a/carta/cpp/desktop/FitsHeaderExtractor.h
+++ b/carta/cpp/desktop/FitsHeaderExtractor.h
@@ -1,0 +1,72 @@
+/**
+ * Class encapsulating algorithms for extracting/computing a fits header from
+ * a carta image.
+ **/
+
+#pragma once
+
+#include "CartaLib/IImage.h"
+#include <QStringList>
+
+namespace casacore { class LatticeBase; }
+
+class FitsHeaderExtractor
+{
+public:
+
+    FitsHeaderExtractor();
+    ~FitsHeaderExtractor();
+
+    /// \brief Set the input image
+    /// \param image pointer to the image from which to extract the header
+    void setInput( Carta::Lib::Image::ImageInterface::SharedPtr image );
+
+    /// \brief get the header
+    /// \return the fits header, with 'END' included as last entry
+    /// empty list indicates an error
+    /// \note all entries are padded/truncated to 80 chars
+    QStringList getHeader();
+
+    /// \return list of errors (if any)
+    QStringList getErrors();
+
+private:
+
+    QString _FITSKeyWordParser(QString _raw);
+    QStringList _CasaFitsConverter( casacore::LatticeBase * lbase);
+
+    Carta::Lib::Image::ImageInterface::SharedPtr m_cartaImage = nullptr;
+    QStringList m_errors;
+};
+
+// FitsLine represents a single entry in the Fits header
+struct FitsLine
+{
+    FitsLine( const QString & rawLine )
+    {
+        _raw = rawLine;
+        _parse( _k, _v, _c );
+    }
+
+    /// return the raw line (verbatim)
+    QString raw() { return _raw; }
+
+    /// extract the keyword from the line
+    QString key() { return _k; }
+
+    /// extract a value from the line
+    QString value() { return _v; }
+
+    /// extract a comment from the line
+    QString comment() {  return _c; }
+
+    /// parse the line into key/value/comment
+    /// \warning throws on syntax error!
+    void _parse( QString & key, QString & value, QString & comment );
+
+    static QString getline(QString & key, QString & value);
+
+protected:
+
+    QString _k, _v, _c, _raw;
+};

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -47,7 +47,10 @@
 
 #include "CartaLib/IImage.h"
 
-#include "FitsHeaderExtractor.h"
+// File_Info implementation test
+// #include "FitsHeaderExtractor.h"
+#include "CartaLib/Hooks/ImageStatisticsHook.h"
+#include "Globals.h"
 
 /// \brief internal class of NewServerConnector, containing extra information we like
 ///  to remember with each view
@@ -349,78 +352,99 @@ void NewServerConnector::onBinaryMessage(char* message, size_t length){
 
         Carta::State::ObjectManager* objMan = Carta::State::ObjectManager::objectManager();
         QString controllerID = this->viewer.m_viewManager->registerView("pluginId:ImageViewer,index:0").split("/").last();
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>( objMan->getObject(controllerID) );
         bool success;
-
-
-        // fileInfoResponse->set_message("File info not available yet!");
+        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>( objMan->getObject(controllerID) );
         CARTA::FileInfoRequest openFile;
         openFile.ParseFromArray(message + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, length - EVENT_NAME_LENGTH - EVENT_ID_LENGTH);
         controller->addData(QString::fromStdString(openFile.directory()) + "/" + QString::fromStdString(openFile.file()), &success);
 
         std::shared_ptr<Carta::Lib::Image::ImageInterface> image = controller->getImage();
-        std::cout << sizeof(image) << std::endl;
-        if (image == NULL)
-        {
-          qWarning() << "No image found!";
-          std::shared_ptr<CARTA::FileInfoResponse> fileInfoResponse(new CARTA::FileInfoResponse());
-          fileInfoResponse->set_success(false);
-          fileInfoResponse->set_message("Something goes wrong! The file is in the list, but the image is not found!");
-        }
-        else
-        {
-          CARTA::FileInfo* fileInfo = new CARTA::FileInfo();
+        std::vector< std::shared_ptr<Carta::Lib::Image::ImageInterface> > images;
+        images.push_back(image);
 
-          // FileInfo: name
-          fileInfo->set_name(openFile.file());
+        CARTA::FileInfo* fileInfo = new CARTA::FileInfo();
 
-          // FileInfo: type
-          if (image->getType() == "FITSImage") {
-              fileInfo->set_type(CARTA::FileType::FITS);
-          } else {
-              fileInfo->set_type(CARTA::FileType::CASA);
-          }
+        // FileInfo: name
+        fileInfo->set_name(openFile.file());
 
-          // FileInfo: size
-          
-          // FileInfo: hdu_list
-          FitsHeaderExtractor fhExtractor;
-          fhExtractor.setInput( image );
-          QStringList header = fhExtractor.getHeader();
-          for (int i = 0; i < header.size(); i++)
-          {
-            // std::cout << i << std::endl;
-            // std::cout << header.size() << std::endl;
-            // std::cout << header.at(i).toLocal8Bit().constData() << std::endl;
-            // list = fileInfo->add_hdu_list();
-            // list->
-            fileInfo->add_hdu_list(header.at(i).toLocal8Bit().constData());
-            // fileInfo->set_hdu_list(list);
-            // fileInfo->set_hdu_list(i, header.at(i).toLocal8Bit().constData());
-          }
-
-          // FileInfoExtended
-
-          const std::vector<int> dims = image->dims();
-          CARTA::FileInfoExtended* fileInfoExt = new CARTA::FileInfoExtended();
-          fileInfoExt->set_dimensions(dims.size());
-          fileInfoExt->set_width(dims[0]);
-          fileInfoExt->set_height(dims[1]);
-          if (dims.size() >= 3) {
-              fileInfoExt->set_depth(dims[2]);
-          }
-          if (dims.size() >= 4) {
-              fileInfoExt->set_stokes(dims[3]);
-          }
-
-          // FileInfoResponse
-          std::shared_ptr<CARTA::FileInfoResponse> fileInfoResponse(new CARTA::FileInfoResponse());
-          fileInfoResponse->set_success(true);
-          fileInfoResponse->set_allocated_file_info(fileInfo);
-          fileInfoResponse->set_allocated_file_info_extended(fileInfoExt);
-          msg = fileInfoResponse;
+        // FileInfo: type
+        if (image->getType() == "FITSImage") {
+            fileInfo->set_type(CARTA::FileType::FITS);
+        } else {
+            fileInfo->set_type(CARTA::FileType::CASA);
         }
 
+        // FileInfo: size
+
+        // FileInfoExtended
+
+        const std::vector<int> dims = image->dims();
+        CARTA::FileInfoExtended* fileInfoExt = new CARTA::FileInfoExtended();
+        fileInfoExt->set_dimensions(dims.size());
+        fileInfoExt->set_width(dims[0]);
+        fileInfoExt->set_height(dims[1]);
+        if (dims.size() >= 3) {
+            fileInfoExt->set_depth(dims[2]);
+        }
+        if (dims.size() >= 4) {
+            fileInfoExt->set_stokes(dims[3]);
+        }
+
+        // Prepare to use the ImageStats plugin.
+        std::vector<std::shared_ptr<Carta::Lib::Regions::RegionBase> > regions;
+        std::vector<int> frameIndices = controller->getImageSlice();
+
+        int sourceCount = images.size();
+        if ( sourceCount > 0 ){
+            auto result = Globals::instance()-> pluginManager()
+                         -> prepare <Carta::Lib::Hooks::ImageStatisticsHook>(images, regions, frameIndices);
+            auto lam = [=] ( const Carta::Lib::Hooks::ImageStatisticsHook::ResultType &data ) {
+              //An array for each image
+              int dataCount = data.size();
+              // m_stateData.resizeArray( STATS, dataCount );
+              for ( int i = 0; i < dataCount; i++ ){
+                  //Each element of the image array contains an array of statistics.
+                  // QString arrayLookup = Carta::State::UtilState::getLookup( "stats", i );
+                  int statCount = data[i].size();
+                  // m_stateData.setArray( arrayLookup, statCount );
+
+                  //Go through each set of statistics for the image.
+                  for ( int k = 0; k < statCount; k++ ){
+                      // QString objLookup = Carta::State::UtilState::getLookup( arrayLookup, k );
+
+                      // QList<QString> existingKeys = m_stateData.getMemberNames( objLookup );
+                      int keyCount = data[i][k].size();
+                      for ( int j = 0; j < keyCount; j++ ){
+                          QString label = data[i][k][j].getLabel();
+                          QString value = data[i][k][j].getValue();
+                          // QString lookup = Carta::State::UtilState::getLookup( objLookup, label );
+                          CARTA::HeaderEntry* headerEntry = fileInfoExt->add_header_entries();
+                          headerEntry->set_name(label.toLocal8Bit().constData());
+                          headerEntry->set_value(value.toLocal8Bit().constData());
+                          // qDebug() << "label:" << label << "lookup" << lookup << "Value: " << data[i][k][j].getValue();
+                          // m_stateData.insertValue<QString>( lookup, data[i][k][j].getValue() );
+                      }
+                  }
+              }
+              // m_stateData.flushState();
+            };
+            try {
+                result.forEach( lam );
+            }
+            catch( char*& error ){
+                QString errorStr( error );
+                qDebug() << "There is an error message: " << error;
+                // Carta::Data::ErrorManager* hr = Carta::State::Util::findSingletonObject<Carta::Data::ErrorManager>();
+                // hr->registerError( errorStr );
+            }
+        }
+
+        // FileInfoResponse
+        std::shared_ptr<CARTA::FileInfoResponse> fileInfoResponse(new CARTA::FileInfoResponse());
+        fileInfoResponse->set_success(true);
+        fileInfoResponse->set_allocated_file_info(fileInfo);
+        fileInfoResponse->set_allocated_file_info_extended(fileInfoExt);
+        msg = fileInfoResponse;
 
         // send the serialized message to the frontend
         sendSerializedMessage(message, respName, msg);

--- a/carta/cpp/desktop/desktop.pro
+++ b/carta/cpp/desktop/desktop.pro
@@ -12,7 +12,8 @@ HEADERS += \
     SessionDispatcher.h \
     # NetworkReplyFileq.h \
     # NetworkAccessManager.h
-    NewServerConnector.h
+    NewServerConnector.h \
+    FitsHeaderExtractor.h \
 
 SOURCES += \
 #    CustomWebPage.cpp \
@@ -22,6 +23,7 @@ SOURCES += \
     SessionDispatcher.cpp \
     # NetworkAccessManager.cpp \
     # NetworkReplyFileq.cpp
+    FitsHeaderExtractor.cpp \
 
 #SOURCES += \
 #    websockettransport.cpp \
@@ -42,16 +44,36 @@ LIBS += -L../../../ThirdParty/protobuf/lib -lprotobuf
 INCLUDEPATH += /usr/local/opt/openssl/include
 LIBS += -L/usr/local/opt/openssl/lib -lssl
 
-INCLUDEPATH += /usr/local/opt/libuv/include
-LIBS += -L/usr/local/opt/libuv/lib -luv
+INCLUDEPATH += /usr/local/Cellar/libuv/1.22.0/include
+LIBS += -L/usr/local/Cellar/libuv/1.22.0/lib -luv
 
 INCLUDEPATH += ../../../ThirdParty/uWebSockets/include
 LIBS += -L../../../ThirdParty/uWebSockets/lib -luWS -lz
+
+casacoreLIBS += -L$${CASACOREDIR}/lib
+casacoreLIBS += -lcasa_lattices -lcasa_tables -lcasa_scimath -lcasa_scimath_f -lcasa_mirlib
+casacoreLIBS += -lcasa_casa -llapack -lblas -ldl
+casacoreLIBS += -lcasa_images -lcasa_coordinates -lcasa_fits -lcasa_measures
+
+LIBS += $${casacoreLIBS}
+LIBS += -L$${WCSLIBDIR}/lib -lwcs
+LIBS += -L$${CFITSIODIR}/lib -lcfitsio
+
+INCLUDEPATH += $${CASACOREDIR}/include
+INCLUDEPATH += $${WCSLIBDIR}/include
+INCLUDEPATH += $${CFITSIODIR}/include
+
+INCLUDEPATH += ../../../ThirdParty/wcslib/include
+LIBS += -L../../../ThirdParty/wcslib/lib -lwcs
+
+INCLUDEPATH += ../../../ThirdParty/cfitsio/include
+LIBS += -L../../../ThirdParty/cfitsio/lib
 
 unix: LIBS += -L$$OUT_PWD/../core/ -lcore
 unix: LIBS += -L$$OUT_PWD/../CartaLib/ -lCartaLib
 DEPENDPATH += $$PROJECT_ROOT/core
 DEPENDPATH += $$PROJECT_ROOT/CartaLib
+
 
 QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../CartaLib:\$$ORIGIN/../core\''
 


### PR DESCRIPTION
Use the ImageStatisticsHook to get the file info. Now it shows the same statistics info as one in the old CARTA. The previous commit uses the FitsHeaderExtractor, which originally used in the WCS plot, to get the raw header info, can be a reference for further extension.