### PR TITLE
Add functionality to plugin PCacheSqlite3

### DIFF
--- a/carta/cpp/CartaLib/IPCache.h
+++ b/carta/cpp/CartaLib/IPCache.h
@@ -47,6 +47,28 @@ public:
               const QByteArray & val,
               const QByteArray & error ) = 0;
 
+    /// for array IO
+        /// read array
+        virtual void
+        setEntry( const std::string & table, const std::vector<double> & value) = 0;
+
+        /// write array
+        virtual bool
+        readEntry( const std::string & table, std::vector<double> & Value) = 0;
+
+        /// create empty array
+        virtual bool
+        createTable( const std::string & table) = 0;
+
+        /// delete array
+        virtual bool
+        deleteTable( const std::string & table) = 0;
+
+        /// list name of arraies
+        virtual void
+        listTable(std::vector<std::string> & Tables) = 0;
+
+
     /// Release the shared_ptr before the program quits.
     /// There may be a better way to prevent the segementation fault
     /// comes from the ~SqLitePCache when CARTA shuts down.

--- a/carta/cpp/cpp.pro
+++ b/carta/cpp/cpp.pro
@@ -10,18 +10,29 @@ SUBDIRS = \
     plugins \
     Tests \
     testCache \
-    testRegion \
-    testPercentile
+#    testRegion \
+#    testPercentile
+
+isEmpty(NOSERVER) {
+	SUBDIRS +=server
+}
 
 # explicit dependencies, to make sure parallel make works (i.e. make -j4...)
 core.depends = CartaLib
 desktop.depends = core
+server.depends = core
 testRegion.depends = core
 plugins.depends = core
 testRegion.depends = core
 testCache.depends = core
 testPercentile.depends = core
-Tests.depends = core desktop plugins
+
+isEmpty(NOSERVER) {
+        Tests.depends = core desktop server plugins
+}
+else{
+        Tests.depends = core desktop plugins
+}
 
 # ... or ...
 # build directories in order, or make sure to update dependencies manually, or make -j4 won't work

--- a/carta/cpp/cpp.pro
+++ b/carta/cpp/cpp.pro
@@ -10,29 +10,18 @@ SUBDIRS = \
     plugins \
     Tests \
     testCache \
-#    testRegion \
-#    testPercentile
-
-isEmpty(NOSERVER) {
-	SUBDIRS +=server
-}
+    testRegion \
+    testPercentile
 
 # explicit dependencies, to make sure parallel make works (i.e. make -j4...)
 core.depends = CartaLib
 desktop.depends = core
-server.depends = core
 testRegion.depends = core
 plugins.depends = core
 testRegion.depends = core
 testCache.depends = core
 testPercentile.depends = core
-
-isEmpty(NOSERVER) {
-        Tests.depends = core desktop server plugins
-}
-else{
-        Tests.depends = core desktop plugins
-}
+Tests.depends = core desktop plugins
 
 # ... or ...
 # build directories in order, or make sure to update dependencies manually, or make -j4 won't work

--- a/carta/cpp/plugins/PCacheLevelDB/PCacheLevelDB.cpp
+++ b/carta/cpp/plugins/PCacheLevelDB/PCacheLevelDB.cpp
@@ -83,6 +83,27 @@ public:
         // \todo we'll have to embed  priority into the value, e.g. first 8 bytes?
     } // setEntry
 
+    /// for array IO
+        /// read array
+        virtual void
+        setEntry( const std::string & table, const std::vector<double> & value) override { }
+
+        /// write array
+        virtual bool
+        readEntry( const std::string & table, std::vector<double> & Value) override { return false;}
+
+        /// create empty array
+        virtual bool
+        createTable( const std::string & table) override { }
+
+        /// delete array
+        virtual bool
+        deleteTable( const std::string & table) override { return false;}
+
+        /// list name of arraies
+        virtual void
+        listTable(std::vector<std::string> & Tables) override { }
+
     static
     Carta::Lib::IPCache::SharedPtr
     getCacheSingleton( QString dirPath)

--- a/carta/cpp/plugins/PCacheSqlite3/PCacheSqlite3.cpp
+++ b/carta/cpp/plugins/PCacheSqlite3/PCacheSqlite3.cpp
@@ -45,11 +45,21 @@ public:
             return;
         }
         QSqlQuery query( m_db );
-        query.prepare( "DELETE FROM db;" );
-
-        if ( ! query.exec() ) {
-            qWarning() << "Delete query failed.";
+        if ( ! query.exec("PRAGMA WRITABLE_SCHEMA = 1;") ) {
+            qWarning() << "Unlock DB permission failed.";
         }
+        if ( ! query.exec("DELETE FROM sqlite_master WHERE TYPE IN ('table');") ) {
+            qWarning() << "Delete all tables failed.";
+        }
+        if ( ! query.exec("PRAGMA WRITABLE_SCHEMA = 0;") ) {
+            qWarning() << "Lock DB permission failed.";
+        }
+        qWarning() << "All tables were deleted.";
+        /// reduce disk usage
+        if ( ! query.exec("VACUUM;") ) {
+            qWarning() << "Vacuum failed.";
+        }
+
     } // deleteAll
 
     virtual bool

--- a/carta/cpp/plugins/PCacheSqlite3/PCacheSqlite3.pro
+++ b/carta/cpp/plugins/PCacheSqlite3/PCacheSqlite3.pro
@@ -5,7 +5,7 @@
 INCLUDEPATH += $$PROJECT_ROOT
 DEPENDPATH += $$PROJECT_ROOT
 
-QT       += core gui sql
+QT       += core sql
 
 TARGET = plugin
 TEMPLATE = lib

--- a/carta/cpp/testCache/testCache.pro
+++ b/carta/cpp/testCache/testCache.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT      +=  network widgets xml
+QT      +=  widgets
 
 HEADERS +=
 
@@ -18,7 +18,6 @@ DEPENDPATH += $$PROJECT_ROOT/CartaLib
 
 QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../CartaLib:\$$ORIGIN/../core\''
 
-#QWT_ROOT = $$absolute_path("../../../ThirdParty/qwt")
 unix:macx {
 #    QMAKE_LFLAGS += '-F$$QWT_ROOT/lib'
 #    LIBS +=-framework qwt


### PR DESCRIPTION
The spectrum of image needs a temporary cache on a disk. An image might contain about 1000 spectrum, one of which has 10000 counts of bin.
We add the functionality to a persistent cache of double precision array in the implementation of Sqlite3. The interface IPCache.h should add the necessary virtual function.
The testing function is added and tested well for the new functionality . The test result shows that IO per seconds can up to the limitation of disk performance.

- setEntry() : check if table exist, if not exist then create a new table, and insert data to table
- readEntry() : if table exist then read all from table
- createTable() : create a table if not exist
- deleteTable() : delete certain table by name
- listTable() : return the name of all tables
- deleteAll() : delete all tables