### PR TITLE
Hjan/remove x11 depend

### DIFF
--- a/carta/cpp/CartaLib/IPlugin.h
+++ b/carta/cpp/CartaLib/IPlugin.h
@@ -4,7 +4,7 @@
 
 #include "CartaLib/Hooks/HookIDs.h"
 #include "IImage.h"
-#include <QImage>
+//#include <QImage>
 #include <QObject>
 #include <QDebug>
 #include <QJsonObject>
@@ -141,13 +141,13 @@ public:
 
     typedef FakeVoid ResultType;
     struct Params {
-        Params( QString p_viewName, QImage * p_imgPtr )
+        Params( QString p_viewName/*, QImage * p_imgPtr*/ )
         {
-            imgPtr = p_imgPtr;
+//            imgPtr = p_imgPtr;
             viewName = p_viewName;
         }
 
-        QImage * imgPtr;
+//        QImage * imgPtr;
         QString viewName;
     };
     PreRender( Params * pptr ) : BaseHook( staticId ), paramsPtr( pptr ) { }

--- a/carta/cpp/CartaLib/IRemoteVGView.cpp
+++ b/carta/cpp/CartaLib/IRemoteVGView.cpp
@@ -4,10 +4,10 @@
 
 #include "IRemoteVGView.h"
 #include "core/IConnector.h"
-#include "VectorGraphics/VGList.h"
+//#include "VectorGraphics/VGList.h"
 
 #include <QTimer>
-#include <QPainter>
+//#include <QPainter>
 
 namespace Carta
 {
@@ -22,60 +22,60 @@ namespace Lib
 //    return std::shared_ptr < LayeredRemoteVGView > ( lv );
 //}
 
-int
-LayeredRemoteVGView::nRasterLayers()
-{
-    return m_rasterLayers.size();
-}
+//int
+//LayeredRemoteVGView::nRasterLayers()
+//{
+//    return m_rasterLayers.size();
+//}
 
-int
-LayeredRemoteVGView::nVGLayers()
-{
-    return m_vgLayers.size();
-}
+//int
+//LayeredRemoteVGView::nVGLayers()
+//{
+//    return m_vgLayers.size();
+//}
 
-int
-LayeredRemoteVGView::nLayers()
-{
-    return nRasterLayers() + nVGLayers();
-}
+//int
+//LayeredRemoteVGView::nLayers()
+//{
+//    return nRasterLayers() + nVGLayers();
+//}
 
-void
-LayeredRemoteVGView::resetLayers()
-{
-    m_vgLayers.clear();
-    m_rasterLayers.clear();
-}
+//void
+//LayeredRemoteVGView::resetLayers()
+//{
+//    m_vgLayers.clear();
+//    m_rasterLayers.clear();
+//}
 
-void
-LayeredRemoteVGView::setRasterLayer( int layer, const QImage & img )
-{
-    CARTA_ASSERT( layer >= 0 && layer < 1000 );
-    if ( int ( m_rasterLayers.size() ) <= layer ) {
-        m_rasterLayers.resize( layer + 1 );
-    }
-    m_rasterLayers[layer].qimg = img;
-}
+//void
+//LayeredRemoteVGView::setRasterLayer( int layer, const QImage & img )
+//{
+//    CARTA_ASSERT( layer >= 0 && layer < 1000 );
+//    if ( int ( m_rasterLayers.size() ) <= layer ) {
+//        m_rasterLayers.resize( layer + 1 );
+//    }
+//    m_rasterLayers[layer].qimg = img;
+//}
 
-void
-LayeredRemoteVGView::setRasterLayerCombiner( int layer, IQImageCombiner::SharedPtr combiner )
-{
-    CARTA_ASSERT( layer >= 0 && layer < 1000 );
-    if ( int ( m_rasterLayers.size() ) <= layer ) {
-        m_rasterLayers.resize( layer + 1 );
-    }
-    m_rasterLayers[layer].combiner = combiner;
-}
+//void
+//LayeredRemoteVGView::setRasterLayerCombiner( int layer, IQImageCombiner::SharedPtr combiner )
+//{
+//    CARTA_ASSERT( layer >= 0 && layer < 1000 );
+//    if ( int ( m_rasterLayers.size() ) <= layer ) {
+//        m_rasterLayers.resize( layer + 1 );
+//    }
+//    m_rasterLayers[layer].combiner = combiner;
+//}
 
-void
-LayeredRemoteVGView::setVGLayer( int layer, const VectorGraphics::VGList & vglist )
-{
-    CARTA_ASSERT( layer >= 0 && layer < 1000 );
-    if ( int ( m_vgLayers.size() ) <= layer ) {
-        m_vgLayers.resize( layer + 1 );
-    }
-    m_vgLayers[layer].vglist = vglist;
-}
+//void
+//LayeredRemoteVGView::setVGLayer( int layer, const VectorGraphics::VGList & vglist )
+//{
+//    CARTA_ASSERT( layer >= 0 && layer < 1000 );
+//    if ( int ( m_vgLayers.size() ) <= layer ) {
+//        m_vgLayers.resize( layer + 1 );
+//    }
+//    m_vgLayers[layer].vglist = vglist;
+//}
 
 QString
 LayeredRemoteVGView::viewName()
@@ -83,26 +83,26 @@ LayeredRemoteVGView::viewName()
     return m_vgView-> getRVGViewName();
 }
 
-QSize
-LayeredRemoteVGView::getClientSize()
-{
-    return m_vgView-> getClientSize();
-}
+//QSize
+//LayeredRemoteVGView::getClientSize()
+//{
+//    return m_vgView-> getClientSize();
+//}
 
-qint64
-LayeredRemoteVGView::scheduleRepaint( qint64 id )
-{
-    if ( id == - 1 ) {
-        id = m_repaintId + 1;
-    }
-    m_repaintId = id;
+//qint64
+//LayeredRemoteVGView::scheduleRepaint( qint64 id )
+//{
+//    if ( id == - 1 ) {
+//        id = m_repaintId + 1;
+//    }
+//    m_repaintId = id;
 
-    if ( ! m_timer-> isActive() ) {
-        m_timer-> start();
-    }
+//    if ( ! m_timer-> isActive() ) {
+//        m_timer-> start();
+//    }
 
-    return m_repaintId;
-}
+//    return m_repaintId;
+//}
 
 LayeredRemoteVGView::LayeredRemoteVGView( IConnector * connector,
                                           QString viewName,
@@ -121,43 +121,43 @@ LayeredRemoteVGView::LayeredRemoteVGView( IConnector * connector,
     //    connect( m_vgView.get(), SIGNAL( sizeChanged() ), this, SIGNAL( sizeChanged() ) );
     connect( m_vgView.get(), & IRemoteVGView::sizeChanged, this, & Me::p_sizeChangedCB );
 
-    m_timer = new QTimer( this );
-    m_timer-> setSingleShot( true );
-    m_timer-> setInterval( 1 );
-    connect( m_timer, & QTimer::timeout, this, & Me::p_timerCB );
+//    m_timer = new QTimer( this );
+//    m_timer-> setSingleShot( true );
+//    m_timer-> setInterval( 1 );
+//    connect( m_timer, & QTimer::timeout, this, & Me::p_timerCB );
 }
 
-void
-LayeredRemoteVGView::p_timerCB()
-{
-    QSize size = getClientSize();
+//void
+//LayeredRemoteVGView::p_timerCB()
+//{
+//    QSize size = getClientSize();
 
-    QImage buff( size, QImage::Format_ARGB32_Premultiplied );
-    buff.fill( QColor( 0, 0, 0, 0 ) );
+//    QImage buff( size, QImage::Format_ARGB32_Premultiplied );
+//    buff.fill( QColor( 0, 0, 0, 0 ) );
 
-    // now go through the layers and paint them on top of the last result
-    for ( auto & layer : m_rasterLayers ) {
-        IQImageCombiner::SharedPtr combiner = layer.combiner;
-        if ( ! combiner ) {
-            combiner = std::make_shared < DefaultCombiner > ();
-        }
-        combiner->combine( buff, layer.qimg );
-    }
-    m_vgView-> setRaster( buff );
+//    // now go through the layers and paint them on top of the last result
+//    for ( auto & layer : m_rasterLayers ) {
+//        IQImageCombiner::SharedPtr combiner = layer.combiner;
+//        if ( ! combiner ) {
+//            combiner = std::make_shared < DefaultCombiner > ();
+//        }
+//        combiner->combine( buff, layer.qimg );
+//    }
+//    m_vgView-> setRaster( buff );
 
-    // concatenate all VG lists into one
-    VectorGraphics::VGComposer composer;
-    for ( auto & vglayer : m_vgLayers ) {
-        composer.append < VectorGraphics::Entries::Reset > ();
-        composer.appendList( vglayer.vglist );
-    }
+//    // concatenate all VG lists into one
+//    VectorGraphics::VGComposer composer;
+//    for ( auto & vglayer : m_vgLayers ) {
+//        composer.append < VectorGraphics::Entries::Reset > ();
+//        composer.appendList( vglayer.vglist );
+//    }
 
-    // render the combined vector graphics list
-    m_vgView-> setVG( composer.vgList() );
+//    // render the combined vector graphics list
+//    m_vgView-> setVG( composer.vgList() );
 
-    // schedule repaint
-    (void) m_vgView-> scheduleRepaint( m_repaintId );
-} // p_timerCB
+//    // schedule repaint
+//    (void) m_vgView-> scheduleRepaint( m_repaintId );
+//} // p_timerCB
 
 void
 LayeredRemoteVGView::p_sizeChangedCB()
@@ -187,10 +187,10 @@ LayeredViewArbitrary::LayeredViewArbitrary( IConnector * connector,
 
     // setup a timer for redrawing (this allows the user to call scheduleRepaint() multiple
     // times, but only one redraw actually happens
-    m_timer = new QTimer( this );
-    m_timer-> setSingleShot( true );
-    m_timer-> setInterval( 1 );
-    connect( m_timer, & QTimer::timeout, this, & Me::p_timerCB );
+//    m_timer = new QTimer( this );
+//    m_timer-> setSingleShot( true );
+//    m_timer-> setInterval( 1 );
+//    connect( m_timer, & QTimer::timeout, this, & Me::p_timerCB );
 }
 
 size_t
@@ -205,21 +205,21 @@ LayeredViewArbitrary::removeAllLayers()
     m_layers.resize( 0 );
 }
 
-void
-LayeredViewArbitrary::setLayerRaster( int ind, const QImage & img, bool hasTransparentPixels )
-{
-    auto & l = linfo( ind );
-    l.qimg = img;
-    l.hasTransparentPixels = hasTransparentPixels && img.hasAlphaChannel();
-    l.type = LayerType::Raster;
-    l.vglist = VectorGraphics::VGList();
-}
+//void
+//LayeredViewArbitrary::setLayerRaster( int ind, const QImage & img, bool hasTransparentPixels )
+//{
+//    auto & l = linfo( ind );
+//    l.qimg = img;
+//    l.hasTransparentPixels = hasTransparentPixels && img.hasAlphaChannel();
+//    l.type = LayerType::Raster;
+//    l.vglist = VectorGraphics::VGList();
+//}
 
-void
-LayeredViewArbitrary::setLayerRaster( int layer, const QImage & img )
-{
-    setLayerRaster( layer, img, img.hasAlphaChannel() );
-}
+//void
+//LayeredViewArbitrary::setLayerRaster( int layer, const QImage & img )
+//{
+//    setLayerRaster( layer, img, img.hasAlphaChannel() );
+//}
 
 LayeredViewArbitrary::LayerInfo &
 LayeredViewArbitrary::linfo( int layer )
@@ -244,15 +244,15 @@ LayeredViewArbitrary::setLayerCombiner( int layer, IQImageCombiner::SharedPtr co
     }
 }
 
-void
-LayeredViewArbitrary::setLayerVG( int layer, const VectorGraphics::VGList & vglist )
-{
-    auto & l = linfo( layer );
-    l.comb = nullptr;
-    l.vglist = vglist;
-    l.qimg = QImage();
-    l.type = LayerType::VG;
-}
+//void
+//LayeredViewArbitrary::setLayerVG( int layer, const VectorGraphics::VGList & vglist )
+//{
+//    auto & l = linfo( layer );
+//    l.comb = nullptr;
+//    l.vglist = vglist;
+//    l.qimg = QImage();
+//    l.type = LayerType::VG;
+//}
 
 void
 LayeredViewArbitrary::setVGrenderedOnServer( bool flag )
@@ -272,11 +272,11 @@ LayeredViewArbitrary::viewName()
     return m_vgView-> getRVGViewName();
 }
 
-QSize
-LayeredViewArbitrary::getClientSize()
-{
-    return m_vgView-> getClientSize();
-}
+//QSize
+//LayeredViewArbitrary::getClientSize()
+//{
+//    return m_vgView-> getClientSize();
+//}
 
 qint64
 LayeredViewArbitrary::scheduleRepaint( qint64 id )
@@ -289,111 +289,111 @@ LayeredViewArbitrary::scheduleRepaint( qint64 id )
 //    if ( ! m_timer-> isActive() ) {
 //        m_timer-> start();
 //    }
-    p_timerCB();
+//    p_timerCB();
 
     return m_repaintId;
 }
 
-void
-LayeredViewArbitrary::p_timerCB()
-{
-    // figure out the size of the buffer (max of the raster sizes)
-//    QSize size( 1, 1 );
-//    for ( auto & layerInfo : m_layers ) {
-//        if ( layerInfo.type != LayerType::Raster ) {
+//void
+//LayeredViewArbitrary::p_timerCB()
+//{
+//    // figure out the size of the buffer (max of the raster sizes)
+////    QSize size( 1, 1 );
+////    for ( auto & layerInfo : m_layers ) {
+////        if ( layerInfo.type != LayerType::Raster ) {
+////            continue;
+////        }
+////        size = size.expandedTo( layerInfo.qimg.size() );
+////    }
+
+//    QSize size = getClientSize();
+
+//    // figure out which layer (from top to bottom) is fully opaque
+//    // we do this because we don't need to render any layer below it
+//    int startLayer = 0;
+
+//    /// \todo implement this
+//    startLayer = m_layers.size();
+//    while ( 1 ) {
+//        startLayer--;
+//        if ( startLayer <= 0 ) {
+//            break;
+//        }
+
+//        // non-raster layer are not candidates
+//        if ( m_layers[startLayer].type != LayerType::Raster ) {
 //            continue;
 //        }
-//        size = size.expandedTo( layerInfo.qimg.size() );
+
+//        // skip over invisible layers
+//        if ( ! m_layers[startLayer].visible ) {
+//            continue;
+//        }
+
+//        // skip rasters with possible transparent pixels
+//        if ( m_layers[startLayer].hasTransparentPixels ) {
+//            continue;
+//        }
+
+//        // skip layers that don't completely fill the size
+//        if ( m_layers[startLayer].qimg.size().width() < size.width() ||
+//             m_layers[startLayer].qimg.size().height() < size.height() ) {
+//            continue;
+//        }
+
+//        // at this point we found a layer that is:
+//        // - raster
+//        // - visible
+//        // - has no alpha pixels
+//        // - occupies every pixel
+//        // so we declare victory
+//        break;
 //    }
 
-    QSize size = getClientSize();
+//    // figure out the last layer we'll need to render on the server (basically
+//    // all the consecutive VG layers from the top can be delegated to the VGView)
+//    /// \todo implement this
 
-    // figure out which layer (from top to bottom) is fully opaque
-    // we do this because we don't need to render any layer below it
-    int startLayer = 0;
+//    // prepare a buffer filled with black pixels
+//    QImage buff( size, QImage::Format_ARGB32_Premultiplied );
+//    buff.fill( QColor( 0, 0, 0, 255 ) );
 
-    /// \todo implement this
-    startLayer = m_layers.size();
-    while ( 1 ) {
-        startLayer--;
-        if ( startLayer <= 0 ) {
-            break;
-        }
+//    IQImageCombiner::SharedPtr defaultComb = std::make_shared < DefaultCombiner > ();
 
-        // non-raster layer are not candidates
-        if ( m_layers[startLayer].type != LayerType::Raster ) {
-            continue;
-        }
+//    // render all the layers from bottom to top
+////    for ( auto & layerInfo : m_layers ) {
+//    for ( size_t i = startLayer ; i < m_layers.size() ; ++i ) {
+//        LayerInfo & layerInfo = m_layers[i];
 
-        // skip over invisible layers
-        if ( ! m_layers[startLayer].visible ) {
-            continue;
-        }
+//        // skip invisible layers
+//        if ( ! layerInfo.visible ) {
+//            continue;
+//        }
 
-        // skip rasters with possible transparent pixels
-        if ( m_layers[startLayer].hasTransparentPixels ) {
-            continue;
-        }
+//        // for raster layers we use the image combiner to draw them
+//        if ( layerInfo.type == LayerType::Raster ) {
+//            if ( layerInfo.comb ) {
+//                layerInfo.comb-> combine( buff, layerInfo.qimg );
+//            }
+//            else {
+//                defaultComb-> combine( buff, layerInfo.qimg );
+//            }
+//        }
 
-        // skip layers that don't completely fill the size
-        if ( m_layers[startLayer].qimg.size().width() < size.width() ||
-             m_layers[startLayer].qimg.size().height() < size.height() ) {
-            continue;
-        }
+//        // for VG layers we VGListQPainterRenderer
+//        else {
+//            QPainter painter( & buff );
+//            Carta::Lib::VectorGraphics::VGListQPainterRenderer renderer;
+//            renderer.render( layerInfo.vglist, painter );
+//            painter.end();
+//        }
+//    }
 
-        // at this point we found a layer that is:
-        // - raster
-        // - visible
-        // - has no alpha pixels
-        // - occupies every pixel
-        // so we declare victory
-        break;
-    }
+//    m_vgView-> setRaster( buff );
 
-    // figure out the last layer we'll need to render on the server (basically
-    // all the consecutive VG layers from the top can be delegated to the VGView)
-    /// \todo implement this
-
-    // prepare a buffer filled with black pixels
-    QImage buff( size, QImage::Format_ARGB32_Premultiplied );
-    buff.fill( QColor( 0, 0, 0, 255 ) );
-
-    IQImageCombiner::SharedPtr defaultComb = std::make_shared < DefaultCombiner > ();
-
-    // render all the layers from bottom to top
-//    for ( auto & layerInfo : m_layers ) {
-    for ( size_t i = startLayer ; i < m_layers.size() ; ++i ) {
-        LayerInfo & layerInfo = m_layers[i];
-
-        // skip invisible layers
-        if ( ! layerInfo.visible ) {
-            continue;
-        }
-
-        // for raster layers we use the image combiner to draw them
-        if ( layerInfo.type == LayerType::Raster ) {
-            if ( layerInfo.comb ) {
-                layerInfo.comb-> combine( buff, layerInfo.qimg );
-            }
-            else {
-                defaultComb-> combine( buff, layerInfo.qimg );
-            }
-        }
-
-        // for VG layers we VGListQPainterRenderer
-        else {
-            QPainter painter( & buff );
-            Carta::Lib::VectorGraphics::VGListQPainterRenderer renderer;
-            renderer.render( layerInfo.vglist, painter );
-            painter.end();
-        }
-    }
-
-    m_vgView-> setRaster( buff );
-
-    // schedule repaint
-    (void) m_vgView-> scheduleRepaint( m_repaintId );
-} // p_timerCB
+//    // schedule repaint
+//    (void) m_vgView-> scheduleRepaint( m_repaintId );
+//} // p_timerCB
 
 // timerCB
 }

--- a/carta/cpp/CartaLib/IRemoteVGView.h
+++ b/carta/cpp/CartaLib/IRemoteVGView.h
@@ -2,12 +2,12 @@
 
 #include "CartaLib.h"
 #include "core/IView.h"
-#include "VectorGraphics/VGList.h"
+//#include "VectorGraphics/VGList.h"
 #include "InputEvents.h"
 
 #include <QObject>
 #include <QString>
-#include <QImage>
+//#include <QImage>
 //#include <QJsonObject>
 //#include <QJsonDocument>
 
@@ -36,14 +36,14 @@ class IRemoteVGView
 
 public:
 
-    typedef Carta::Lib::VectorGraphics::VGList VGList;
+//    typedef Carta::Lib::VectorGraphics::VGList VGList;
 
     /// constructor
     IRemoteVGView( QObject * parent ) : QObject( parent ) { }
 
     /// returns size of the view in client (the master's UI)
-    virtual const QSize &
-    getClientSize() = 0;
+//    virtual const QSize &
+//    getClientSize() = 0;
 
     /// returns the unique name of this view
     virtual const QString &
@@ -54,14 +54,14 @@ public:
     virtual void
     setRaster( const QImage & image ) = 0;
 
-    /// sets the VG to be rendered on top of the raster, as soon as possible
-    /// without synchronizing with raster
-    virtual void
-    setVG( const VGList & vglist ) = 0;
+//    /// sets the VG to be rendered on top of the raster, as soon as possible
+//    /// without synchronizing with raster
+//    virtual void
+//    setVG( const VGList & vglist ) = 0;
 
-    /// sets the raster and VG simultaneously, making sure both appear at the same time
-    virtual void
-    setRasterAndVG( const QImage & image, const VGList & vglist ) = 0;
+//    /// sets the raster and VG simultaneously, making sure both appear at the same time
+//    virtual void
+//    setRasterAndVG( const QImage & image, const VGList & vglist ) = 0;
 
     /// sets where VG rendered (client vs server)
     virtual void
@@ -151,11 +151,11 @@ public:
     int
     nRasterLayers();
 
-    int
-    nVGLayers();
+//    int
+//    nVGLayers();
 
-    int
-    nLayers();
+//    int
+//    nLayers();
 
     void
     resetLayers();
@@ -166,8 +166,8 @@ public:
     void
     setRasterLayerCombiner( int layer, IQImageCombiner::SharedPtr combiner );
 
-    void
-    setVGLayer( int layer, const VectorGraphics::VGList & vglist );
+//    void
+//    setVGLayer( int layer, const VectorGraphics::VGList & vglist );
 
     QString
     viewName();
@@ -179,8 +179,8 @@ public slots:
 
     /// schedule a refresh with a given ID
     /// this allows the caller to be notified when the latest painting has reached the client
-    qint64
-    scheduleRepaint( qint64 id = - 1 );
+//    qint64
+//    scheduleRepaint( qint64 id = - 1 );
 
 signals:
 
@@ -200,25 +200,25 @@ private:
 
     IRemoteVGView::UniquePtr m_vgView = nullptr;
 
-    struct RasterLayerInfo {
-        QImage qimg;
-        IQImageCombiner::SharedPtr combiner = nullptr;
-    };
+//    struct RasterLayerInfo {
+//        QImage qimg;
+//        IQImageCombiner::SharedPtr combiner = nullptr;
+//    };
 
-    struct VGLayerInfo {
-        VectorGraphics::VGList vglist;
-    };
+//    struct VGLayerInfo {
+//        VectorGraphics::VGList vglist;
+//    };
 
-    std::vector < RasterLayerInfo > m_rasterLayers;
-    std::vector < VGLayerInfo > m_vgLayers;
+//    std::vector < RasterLayerInfo > m_rasterLayers;
+//    std::vector < VGLayerInfo > m_vgLayers;
 
     qint64 m_repaintId = - 1;
-    QTimer * m_timer = nullptr;
+//    QTimer * m_timer = nullptr;
 
 private slots:
 
-    void
-    p_timerCB();
+//    void
+//    p_timerCB();
 
     void
     p_sizeChangedCB();
@@ -242,47 +242,47 @@ private slots:
 /// it does honor the alphas of the source pixels
 /// it's also possible to set the alpha for the whole
 /// src image
-class AlphaCombiner : public IQImageCombiner
-{
-public:
+//class AlphaCombiner : public IQImageCombiner
+//{
+//public:
 
-    AlphaCombiner( double alpha = 1.0 )
-    {
-        setAlpha( alpha );
-    }
+//    AlphaCombiner( double alpha = 1.0 )
+//    {
+//        setAlpha( alpha );
+//    }
 
-    void
-    setAlpha( double alpha )
-    {
-        CARTA_ASSERT( alpha >= 0.0 && alpha <= 1.0 );
-        m_alpha = alpha;
-    }
+//    void
+//    setAlpha( double alpha )
+//    {
+//        CARTA_ASSERT( alpha >= 0.0 && alpha <= 1.0 );
+//        m_alpha = alpha;
+//    }
 
-    virtual void
-    combine( QImage & src1dst, const QImage & src2 ) override
-    {
-        // small optimization for alpha = 0, and for empty source or destination
-        if ( m_alpha == 0.0 || src1dst.size().isEmpty() || src2.size().isEmpty() ) {
-            return;
-        }
-        QPainter p( & src1dst );
-        p.setOpacity( m_alpha );
-        p.drawImage( 0, 0, src2 );
-    }
+//    virtual void
+//    combine( QImage & src1dst, const QImage & src2 ) override
+//    {
+//        // small optimization for alpha = 0, and for empty source or destination
+//        if ( m_alpha == 0.0 || src1dst.size().isEmpty() || src2.size().isEmpty() ) {
+//            return;
+//        }
+//        QPainter p( & src1dst );
+//        p.setOpacity( m_alpha );
+//        p.drawImage( 0, 0, src2 );
+//    }
 
-    virtual bool
-    isOpaque()  override
-    {
-        return m_alpha == 1.0;
-    }
+//    virtual bool
+//    isOpaque()  override
+//    {
+//        return m_alpha == 1.0;
+//    }
 
-private:
+//private:
 
-    double m_alpha = 1.0;
-};
+//    double m_alpha = 1.0;
+//};
 
 /// the default combiner is the AlphaCombiner
-using DefaultCombiner = AlphaCombiner;
+//using DefaultCombiner = AlphaCombiner;
 
 /// applies an RGB mask to the source pixels before painting the source image
 /// over the destination
@@ -293,70 +293,70 @@ using DefaultCombiner = AlphaCombiner;
 /// alpha
 /// mask
 /// composition mode
-class PixelMaskCombiner : public IQImageCombiner
-{
-public:
+//class PixelMaskCombiner : public IQImageCombiner
+//{
+//public:
 
-    void
-    setCompositionMode( const QPainter::CompositionMode & mode = QPainter::CompositionMode_Plus )
-    {
-        m_compositionMode = mode;
-    }
+//    void
+//    setCompositionMode( const QPainter::CompositionMode & mode = QPainter::CompositionMode_Plus )
+//    {
+//        m_compositionMode = mode;
+//    }
 
-    void
-    setMask( quint32 mask = DefaultMask )
-    {
-        m_mask = mask;
-    }
+//    void
+//    setMask( quint32 mask = DefaultMask )
+//    {
+//        m_mask = mask;
+//    }
 
-    void
-    setAlpha( double alpha = 1.0 )
-    {
-        CARTA_ASSERT( alpha >= 0.0 && alpha <= 1.0 );
-        m_alpha = alpha;
-    }
+//    void
+//    setAlpha( double alpha = 1.0 )
+//    {
+//        CARTA_ASSERT( alpha >= 0.0 && alpha <= 1.0 );
+//        m_alpha = alpha;
+//    }
 
-    virtual void
-    combine( QImage & src1dst, const QImage & src2 ) override
-    {
-        // small optimization for alpha = 0, and for empty source or destination
-        if ( m_alpha == 0.0 || src1dst.size().isEmpty() || src2.size().isEmpty() ) {
-            return;
-        }
+//    virtual void
+//    combine( QImage & src1dst, const QImage & src2 ) override
+//    {
+//        // small optimization for alpha = 0, and for empty source or destination
+//        if ( m_alpha == 0.0 || src1dst.size().isEmpty() || src2.size().isEmpty() ) {
+//            return;
+//        }
 
-        // make a copy of the source image
-        QImage src22 = src2;
+//        // make a copy of the source image
+//        QImage src22 = src2;
 
-        // make sure it's in ARGB32 format
-        if ( src22.format() != QImage::Format_ARGB32 ) {
-            src22 = src22.convertToFormat( QImage::Format_ARGB32 );
-        }
+//        // make sure it's in ARGB32 format
+//        if ( src22.format() != QImage::Format_ARGB32 ) {
+//            src22 = src22.convertToFormat( QImage::Format_ARGB32 );
+//        }
 
-        // apply in-place mask on the copy
-        for ( int y = 0 ; y < src2.height() ; y++ ) {
-            unsigned char * chr = src22.scanLine( y );
-            QRgb * ptr = (QRgb *) ( chr );
-            for ( int x = 0 ; x < src22.width() ; x++ ) {
-                * ptr = ( * ptr ) & m_mask;
-                ptr++;
-            }
-        }
+//        // apply in-place mask on the copy
+//        for ( int y = 0 ; y < src2.height() ; y++ ) {
+//            unsigned char * chr = src22.scanLine( y );
+//            QRgb * ptr = (QRgb *) ( chr );
+//            for ( int x = 0 ; x < src22.width() ; x++ ) {
+//                * ptr = ( * ptr ) & m_mask;
+//                ptr++;
+//            }
+//        }
 
-        // draw the masked copy on top of the source
-        QPainter p( & src1dst );
-        p.setCompositionMode( m_compositionMode );
-        p.setOpacity( m_alpha );
-        p.drawImage( 0, 0, src22 );
-    } // combine
+//        // draw the masked copy on top of the source
+//        QPainter p( & src1dst );
+//        p.setCompositionMode( m_compositionMode );
+//        p.setOpacity( m_alpha );
+//        p.drawImage( 0, 0, src22 );
+//    } // combine
 
-    static constexpr quint32 DefaultMask = 0xffffffff;
+//    static constexpr quint32 DefaultMask = 0xffffffff;
 
-private:
+//private:
 
-    QPainter::CompositionMode m_compositionMode = QPainter::CompositionMode_Plus;
-    quint32 m_mask = DefaultMask;
-    double m_alpha = 1.0;
-};
+//    QPainter::CompositionMode m_compositionMode = QPainter::CompositionMode_Plus;
+//    quint32 m_mask = DefaultMask;
+//    double m_alpha = 1.0;
+//};
 
 /// Similar to LayeredRemoteVGView but the layers can be ordered arbitrarily, e.g.
 /// you can have a raster layer above a VG layer.
@@ -382,10 +382,10 @@ class LayeredViewArbitrary
     struct LayerInfo {
         LayerType type;
         bool visible = true;
-        QImage qimg;
+//        QImage qimg;
         bool hasTransparentPixels = false;
         IQImageCombiner::SharedPtr comb = nullptr;
-        VectorGraphics::VGList vglist;
+//        VectorGraphics::VGList vglist;
     };
 
 public:
@@ -417,9 +417,9 @@ public:
     void
     setLayerCombiner( int layer, IQImageCombiner::SharedPtr combiner );
 
-    /// set the layer to be a VG layer with the given content
-    void
-    setLayerVG( int layer, const VectorGraphics::VGList & vglist );
+//    /// set the layer to be a VG layer with the given content
+//    void
+//    setLayerVG( int layer, const VectorGraphics::VGList & vglist );
 
     void
     setLayerVisibility( int layer, bool flag );
@@ -439,8 +439,8 @@ public:
     QString
     viewName();
 
-    QSize
-    getClientSize();
+//    QSize
+//    getClientSize();
 
 public slots:
 
@@ -469,7 +469,7 @@ private:
     std::vector < LayerInfo > m_layers;
 
     qint64 m_repaintId = - 1;
-    QTimer * m_timer = nullptr;
+//    QTimer * m_timer = nullptr;
 
     // helper to create and return reference to a layer
     LayeredViewArbitrary::LayerInfo &
@@ -477,8 +477,8 @@ private:
 
 private slots:
 
-    void
-    p_timerCB();
+//    void
+//    p_timerCB();
 
 //    void
 //    p_sizeChangedCB();

--- a/carta/cpp/core/Data/Animator/Animator.cpp
+++ b/carta/cpp/core/Data/Animator/Animator.cpp
@@ -209,34 +209,34 @@ void Animator::_axesChanged(){
     }
 }
 
-void Animator::changeFrame( int index, const QString& animName ){
-    int linkCount = m_linkImpl->getLinkCount();
-    for( int i = 0; i < linkCount; i++ ){
-        Controller* controller = dynamic_cast<Controller*>( m_linkImpl->getLink(i));
-        if ( controller != nullptr ){
-            if ( animName == Selection::IMAGE ){
-                controller->setFrameImage( index );
-            }
-            else if ( animName == Selection::REGION ){
-            	controller->setFrameRegion( index );
-            }
-            else {
-                AxisInfo::KnownType axisType = AxisMapper::getType( animName );
-                if ( axisType != AxisInfo::KnownType::OTHER ){
-                    controller->_setFrameAxis( index, axisType );
-                }
-            }
-        }
-    }
-}
+//void Animator::changeFrame( int index, const QString& animName ){
+//    int linkCount = m_linkImpl->getLinkCount();
+//    for( int i = 0; i < linkCount; i++ ){
+//        Controller* controller = dynamic_cast<Controller*>( m_linkImpl->getLink(i));
+//        if ( controller != nullptr ){
+//            if ( animName == Selection::IMAGE ){
+//                controller->setFrameImage( index );
+//            }
+//            else if ( animName == Selection::REGION ){
+//            	controller->setFrameRegion( index );
+//            }
+//            else {
+//                AxisInfo::KnownType axisType = AxisMapper::getType( animName );
+//                if ( axisType != AxisInfo::KnownType::OTHER ){
+//                    controller->_setFrameAxis( index, axisType );
+//                }
+//            }
+//        }
+//    }
+//}
 
 void Animator::clear(){
     m_linkImpl->clear();
 }
 
-void Animator::_frameChanged( int index, const QString& axisName ){
-    changeFrame( index, axisName );
-}
+//void Animator::_frameChanged( int index, const QString& axisName ){
+//    changeFrame( index, axisName );
+//}
 
 AnimatorType* Animator::getAnimator( const QString& type ){
     AnimatorType* animator = nullptr;

--- a/carta/cpp/core/Data/Animator/Animator.h
+++ b/carta/cpp/core/Data/Animator/Animator.h
@@ -55,7 +55,7 @@ public:
      * @param axisName - an identifier for the axis.
      * @param index - the index of the new axis frame.
      */
-    void changeFrame( int index, const QString& axisName );
+//    void changeFrame( int index, const QString& axisName );
 
     /**
      * Clear current state..
@@ -150,7 +150,7 @@ private slots:
     //Adjusts internal state based on the state in the child controllers.
     void _adjustStateController( Controller* controller);
     void _axesChanged();
-    void _frameChanged( int index, const QString& axisName );
+//    void _frameChanged( int index, const QString& axisName );
     void _regionsChanged( Controller* controller );
     void _updateFrame( Controller* controller, Carta::Lib::AxisInfo::KnownType type );
 

--- a/carta/cpp/core/Data/Colormap/Colormap.cpp
+++ b/carta/cpp/core/Data/Colormap/Colormap.cpp
@@ -157,15 +157,15 @@ void Colormap::_calculateColorStops(){
                     // fill Hex color codes in a string list
                     Carta::Lib::PixelPipeline::NormRgb normRgb;
                     pipe->convert( val, normRgb );
-                    QColor mapColor;
-                    if ( normRgb[0] >= 0 && normRgb[1] >= 0 && normRgb[2] >= 0 ){
-                    	mapColor = QColor::fromRgbF( normRgb[0], normRgb[1], normRgb[2] );
-                    }
-                    QString hexStr = mapColor.name();
-                    if ( i < 99 ){
-                        hexStr = hexStr + ",";
-                    }
-                    buff.append( hexStr );
+//                    QColor mapColor;
+//                    if ( normRgb[0] >= 0 && normRgb[1] >= 0 && normRgb[2] >= 0 ){
+//                    	mapColor = QColor::fromRgbF( normRgb[0], normRgb[1], normRgb[2] );
+//                    }
+//                    QString hexStr = mapColor.name();
+//                    if ( i < 99 ){
+//                        hexStr = hexStr + ",";
+//                    }
+//                    buff.append( hexStr );
                 }
                 m_state.setValue<QString>( COLOR_STOPS, buff.join("") );
 

--- a/carta/cpp/core/Data/DataLoader.cpp
+++ b/carta/cpp/core/Data/DataLoader.cpp
@@ -13,6 +13,7 @@
 #include "State/UtilState.h"
 
 #include <set>
+#include <math.h>
 
 using Carta::Lib::AxisInfo;
 
@@ -387,38 +388,38 @@ bool DataLoader::_getStatisticInfo(std::map<QString, QString>& infoMap,
     images.push_back(image);
     
     // regions is an empty setting so far
-    std::vector<std::shared_ptr<Carta::Lib::Regions::RegionBase>> regions;
+//    std::vector<std::shared_ptr<Carta::Lib::Regions::RegionBase>> regions;
     
     // get the statistical data of the whole image
     std::vector<int> frameIndices(image->dims().size(), -1);
 
-    if (images.size() > 0) { // [TODO]: do we really need this if statement?
-        // Prepare to use the ImageStats plugin.
-        auto result = Globals::instance()->pluginManager()
-                -> prepare <Carta::Lib::Hooks::ImageStatisticsHook>(images, regions, frameIndices);
+//    if (images.size() > 0) { // [TODO]: do we really need this if statement?
+//        // Prepare to use the ImageStats plugin.
+//        auto result = Globals::instance()->pluginManager()
+//                -> prepare <Carta::Lib::Hooks::ImageStatisticsHook>(images, regions, frameIndices);
 
-        // lamda function for traverse
-        auto lam = [&] (const Carta::Lib::Hooks::ImageStatisticsHook::ResultType &data) {
-            //An array for each image
-            for (int i = 0; i < data.size(); i++) {
-                // Each element of the image array contains an array of statistics.
-                // Go through each set of statistics for the image.
-                for (int j = 0; j < data[i].size(); j++) {
-                    for (int k = 0; k < data[i][j].size(); k++) {
-                        infoMap[data[i][j][k].getLabel()] = data[i][j][k].getValue();
-                    }
-                }
-            }
-        };
+//        // lamda function for traverse
+//        auto lam = [&] (const Carta::Lib::Hooks::ImageStatisticsHook::ResultType &data) {
+//            //An array for each image
+//            for (int i = 0; i < data.size(); i++) {
+//                // Each element of the image array contains an array of statistics.
+//                // Go through each set of statistics for the image.
+//                for (int j = 0; j < data[i].size(); j++) {
+//                    for (int k = 0; k < data[i][j].size(); k++) {
+//                        infoMap[data[i][j][k].getLabel()] = data[i][j][k].getValue();
+//                    }
+//                }
+//            }
+//        };
 
-        try {
-            result.forEach(lam);
-        } catch (char*& error) {
-            QString errorStr(error);
-            qDebug() << "[File Info] There is an error message: " << errorStr;
-            return false;
-        }
-    }
+//        try {
+//            result.forEach(lam);
+//        } catch (char*& error) {
+//            QString errorStr(error);
+//            qDebug() << "[File Info] There is an error message: " << errorStr;
+//            return false;
+//        }
+//    }
 
     return true;
 }

--- a/carta/cpp/core/Data/DataLoader.h
+++ b/carta/cpp/core/Data/DataLoader.h
@@ -20,7 +20,7 @@
 
 // File_Info implementation needs
 #include "CartaLib/Hooks/LoadAstroImage.h"
-#include "CartaLib/Hooks/ImageStatisticsHook.h"
+//#include "CartaLib/Hooks/ImageStatisticsHook.h"
 #include "Globals.h"
 
 namespace Carta {

--- a/carta/cpp/core/Data/Histogram/Histogram.cpp
+++ b/carta/cpp/core/Data/Histogram/Histogram.cpp
@@ -2210,7 +2210,7 @@ void Histogram::_updatePlots( ){
 	for ( int i = 0; i < dataCount; i++ ){
 		Carta::Lib::Hooks::HistogramResult result = m_binDatas[i]->getHistogramResult();
 		m_plotManager->addData( &result );
-		m_plotManager->setColor( m_binDatas[i]->getColor(), result.getName());
+//		m_plotManager->setColor( m_binDatas[i]->getColor(), result.getName());
 	}
 	//Refresh the view
 	m_plotManager->setLogScale( m_state.getValue<bool>( GRAPH_LOG_COUNT ) );

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -110,7 +110,7 @@ Controller::Controller( const QString& path, const QString& id ) :
 	Settings* settingsObj = objMan->createObject<Settings>();
 	m_settings.reset( settingsObj );
 
-	_initializeCallbacks();
+//	_initializeCallbacks();
 
 	RegionControls* regionObj = objMan->createObject<RegionControls>();
 	connect( regionObj, SIGNAL(regionsChanged()), this, SLOT(_regionsChanged()));
@@ -298,13 +298,13 @@ std::shared_ptr<DataSource> Controller::getDataSource() const {
     return m_stack->_getDataSource();
 }
 
-QPointF Controller::getImagePt( bool* valid ) const {
-    int mouseX = m_stateMouse.getValue<int>(ImageView::MOUSE_X);
-    int mouseY = m_stateMouse.getValue<int>(ImageView::MOUSE_Y);
-    QPointF mousePt( mouseX, mouseY );
-    QSize outputSize = getOutputSize();
-    return m_stack->_getImagePt( mousePt,  outputSize, valid  );
-}
+//QPointF Controller::getImagePt( bool* valid ) const {
+//    int mouseX = m_stateMouse.getValue<int>(ImageView::MOUSE_X);
+//    int mouseY = m_stateMouse.getValue<int>(ImageView::MOUSE_Y);
+//    QPointF mousePt( mouseX, mouseY );
+//    QSize outputSize = getOutputSize();
+//    return m_stack->_getImagePt( mousePt,  outputSize, valid  );
+//}
 
 
 std::vector< std::shared_ptr<Layer> > Controller::getLayers() {
@@ -414,15 +414,15 @@ PBMSharedPtr Controller::getRasterImageData(int fileId, int x_min, int x_max, in
     return result;
 }
 
-QRectF Controller::_getInputRectangle(  ) const {
-    return m_stack->_getInputRectangle( );
-}
+//QRectF Controller::_getInputRectangle(  ) const {
+//    return m_stack->_getInputRectangle( );
+//}
 
 
-QSize Controller::getOutputSize( ) const {
-    QSize result = m_stack->_getOutputSize();
-    return result;
-}
+//QSize Controller::getOutputSize( ) const {
+//    QSize result = m_stack->_getOutputSize();
+//    return result;
+//}
 
 
 std::vector<double> Controller::getPercentiles( int frameLow, int frameHigh, std::vector<double> intensities, Carta::Lib::IntensityUnitConverter::SharedPtr converter ) const {
@@ -544,857 +544,857 @@ double Controller::getZoomLevel( ) const {
 //     _setSkyCSName();
 // }
 
-void Controller::_onInputEvent( InputEvent  ev ){
+//void Controller::_onInputEvent( InputEvent  ev ){
 
-	Carta::Lib::InputEvents::HoverEvent hover( ev );
-	if ( hover.isValid() ){
-		QPointF target = hover.pos();
-		int mouseX = target.x();
-		int mouseY = target.y();
-		_updateCursor( mouseX, mouseY );
+//	Carta::Lib::InputEvents::HoverEvent hover( ev );
+//	if ( hover.isValid() ){
+//		QPointF target = hover.pos();
+//		int mouseX = target.x();
+//		int mouseY = target.y();
+//		_updateCursor( mouseX, mouseY );
 
-	}
+//	}
 
-	Carta::Lib::InputEvents::PointerEvent pointer( ev );
-	if ( pointer.isValid() ){
-		bool valid = false;
-		QSize outputSize = getOutputSize();
-		QPointF pointPt = pointer.pos();
-		QPointF imagePixelPt = m_stack->_getImagePt( pointPt,  outputSize, &valid  );
-		if ( valid ){
-			//Only handle region events that are inside the image itself.
-			Carta::Lib::AxisInfo::KnownType xType = m_stack->_getAxisXType();
-			Carta::Lib::AxisInfo::KnownType yType = m_stack->_getAxisYType();
-			int frameCountX = m_stack->_getFrameCount( xType );
-			int frameCountY = m_stack->_getFrameCount( yType );
-
-
-			if ( 0 <= imagePixelPt.x() && imagePixelPt.x() <= frameCountX ){
-				if ( 0 <= imagePixelPt.y() && imagePixelPt.y() <= frameCountY ){
-					m_regionControls->_onInputEvent( ev, imagePixelPt );
-				}
-			}
-		}
-	}
-
-	//Note:  we set the event consumed if we are editing a region to prevent
-	//a subsequent pan operation.
-	if ( ! ev.isConsumed() ){
-		Carta::Lib::InputEvents::DoubleTapEvent doubleTap( ev );
-		if ( doubleTap.isValid() ){
-			QPointF target = doubleTap.pos();
-			int mouseX = target.x();
-			int mouseY = target.y();
-			updatePan( mouseX, mouseY );
-		}
-	}
-}
-
-void Controller::_initializeCallbacks(){
-
-    // addCommandCallback( "testProtoBuf", [=] (const QString & /*cmd*/,
-    //         const QString & params, const QString & /*sessionId*/) -> QString {
-    //     QString result;
-    //     std::string data;
-    //     lm::helloworld msg1;
-    //     msg1.set_id(101);
-    //     msg1.set_str("hello");
-    //     msg1.SerializeToString(&data);
-    //     result = QString::fromStdString(data);
-    //     return result;
-    // });
-    //addMessageCallback( "testProtoBuf", [=] (const QString & /*cmd*/,
-    //        const QString & params, const QString & /*sessionId*/) -> PBMSharedPtr {
-    //    std::shared_ptr<lm::helloworld> msg1(new lm::helloworld());
-    //    msg1->set_id(101);
-    //    msg1->set_str("hello");
-    //    return static_cast<PBMSharedPtr>(msg1);
-    //});
-
-    // addMessageCallback( "OPEN_FILE", [=] (const QString & /*cmd*/,
-    //         const QString & params, const QString & /*sessionId*/) -> PBMSharedPtr {
-
-    //     CARTA::FileInfo* fileInfo = new CARTA::FileInfo();
-    //     fileInfo->set_name("test");
-    //     fileInfo->set_type()
-
-    //     std::shared_ptr<CARTA::OpenFileAck> ack(new CARAT::OpenFileAck());
-    //     ack->set_success(true);
-    //     ack->set_allocated_file_info(fileInfo);
-    // });
-
-    addCommandCallback( "hideImage", [=] (const QString & /*cmd*/,
-                        const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = {Util::ID};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString idStr = dataValues[*keys.begin()];
-        QString result = setImageVisibility( /*imageIndex*/idStr, false );
-        Util::commandPostProcess( result );
-        return result;
-    });
-
-    addCommandCallback( "moveLayers", [=] (const QString & /*cmd*/,
-                                    const QString & params, const QString & /*sessionId*/) -> QString {
-                std::set<QString> keys = {"moveDown"};
-                std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-                QString moveDownStr = dataValues[*keys.begin()];
-                bool validBool = false;
-                bool moveDown = Util::toBool( moveDownStr, &validBool );
-                QString result;
-                if ( validBool ){
-                    result = moveSelectedLayers( moveDown );
-                }
-                else {
-                    result = "Whether to move up or down selected layers must be true/false: "+params;
-                }
-                Util::commandPostProcess( result );
-                return result;
-            });
-
-    addCommandCallback( "setGroup", [=] (const QString & /*cmd*/,
-                                const QString & params, const QString & /*sessionId*/) -> QString {
-            std::set<QString> keys = {Layer::GROUP};
-            std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-            QString groupSelects = dataValues[*keys.begin()];
-            bool validBool = false;
-            bool group = Util::toBool( groupSelects, &validBool );
-            QString result;
-            if ( validBool ){
-                result = setSelectedLayersGrouped( group );
-            }
-            else {
-                result = "Grouping layers must be true/false: "+params;
-            }
-            Util::commandPostProcess( result );
-            return result;
-        });
-
-    addCommandCallback( "showImage", [=] (const QString & /*cmd*/,
-                            const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = {Util::ID};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString idStr = dataValues[*keys.begin()];
-        QString result = setImageVisibility( idStr, true );
-        Util::commandPostProcess( result );
-        return result;
-    });
+//	Carta::Lib::InputEvents::PointerEvent pointer( ev );
+//	if ( pointer.isValid() ){
+//		bool valid = false;
+//		QSize outputSize = getOutputSize();
+//		QPointF pointPt = pointer.pos();
+//		QPointF imagePixelPt = m_stack->_getImagePt( pointPt,  outputSize, &valid  );
+//		if ( valid ){
+//			//Only handle region events that are inside the image itself.
+//			Carta::Lib::AxisInfo::KnownType xType = m_stack->_getAxisXType();
+//			Carta::Lib::AxisInfo::KnownType yType = m_stack->_getAxisYType();
+//			int frameCountX = m_stack->_getFrameCount( xType );
+//			int frameCountY = m_stack->_getFrameCount( yType );
 
 
+//			if ( 0 <= imagePixelPt.x() && imagePixelPt.x() <= frameCountX ){
+//				if ( 0 <= imagePixelPt.y() && imagePixelPt.y() <= frameCountY ){
+//					m_regionControls->_onInputEvent( ev, imagePixelPt );
+//				}
+//			}
+//		}
+//	}
 
-    //Listen for updates to the clip and reload the frame.
-    addCommandCallback( "setClipValue", [=] (const QString & /*cmd*/,
-                const QString & params, const QString & /*sessionId*/) -> QString {
-        QString result;
-        std::set<QString> keys = {"clipValue"};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        bool validClip = false;
-        QString clipKey = *keys.begin();
-        QString clipWithoutPercent = dataValues[clipKey].remove("%");
-        double clipVal = dataValues[clipKey].toDouble(&validClip);
-        if ( validClip ){
-            result = setClipValue( clipVal );
-        }
-        else {
-            result = "Invalid clip value: "+params;
-        }
-        Util::commandPostProcess( result );
-        return result;
-    });
+//	//Note:  we set the event consumed if we are editing a region to prevent
+//	//a subsequent pan operation.
+//	if ( ! ev.isConsumed() ){
+//		Carta::Lib::InputEvents::DoubleTapEvent doubleTap( ev );
+//		if ( doubleTap.isValid() ){
+//			QPointF target = doubleTap.pos();
+//			int mouseX = target.x();
+//			int mouseY = target.y();
+//			updatePan( mouseX, mouseY );
+//		}
+//	}
+//}
 
-    addCommandCallback( "setAutoClip", [=] (const QString & /*cmd*/,
-                    const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = {"autoClip"};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString clipKey = *keys.begin();
-        bool validBool = false;
-        bool autoClip = Util::toBool( dataValues[clipKey], &validBool );
-        QString result;
-        if ( validBool ){
-            setAutoClip( autoClip );
-        }
-        else {
-            result = "Auto clip must be true/false: "+params;
-        }
-        Util::commandPostProcess( result );
-        return result;
-    });
+//void Controller::_initializeCallbacks(){
 
-    addCommandCallback( "setPanZoomAll", [=] (const QString & /*cmd*/,
-                        const QString & params, const QString & /*sessionId*/) -> QString {
-            std::set<QString> keys = {"panZoomAll"};
-            std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-            QString panZoomKey = *keys.begin();
-            bool validBool = false;
-            bool panZoomAll = Util::toBool( dataValues[panZoomKey], &validBool );
-            QString result;
-            if ( validBool ){
-                setPanZoomAll( panZoomAll );
-            }
-            else {
-                result = "Pan/Zoom All must be true/false: "+params;
-            }
-            Util::commandPostProcess( result );
-            return result;
-        });
+//    // addCommandCallback( "testProtoBuf", [=] (const QString & /*cmd*/,
+//    //         const QString & params, const QString & /*sessionId*/) -> QString {
+//    //     QString result;
+//    //     std::string data;
+//    //     lm::helloworld msg1;
+//    //     msg1.set_id(101);
+//    //     msg1.set_str("hello");
+//    //     msg1.SerializeToString(&data);
+//    //     result = QString::fromStdString(data);
+//    //     return result;
+//    // });
+//    //addMessageCallback( "testProtoBuf", [=] (const QString & /*cmd*/,
+//    //        const QString & params, const QString & /*sessionId*/) -> PBMSharedPtr {
+//    //    std::shared_ptr<lm::helloworld> msg1(new lm::helloworld());
+//    //    msg1->set_id(101);
+//    //    msg1->set_str("hello");
+//    //    return static_cast<PBMSharedPtr>(msg1);
+//    //});
 
-    /*QString pointerPath= UtilState::getLookup( getPath(), UtilState::getLookup( Util::VIEW, Util::POINTER_MOVE));
-    addStateCallback( pointerPath, [=] ( const QString& path, const QString& value ) {
-        QStringList mouseList = value.split( " ");
-        if ( mouseList.size() == 2 ){
-            bool validX = false;
-            int mouseX = mouseList[0].toInt( &validX );
-            bool validY = false;
-            int mouseY = mouseList[1].toInt( &validY );
-            if ( validX && validY ){
-                _updateCursor( mouseX, mouseY );
-                emit zoomChanged();
-            }
-        }
-    });*/
+//    // addMessageCallback( "OPEN_FILE", [=] (const QString & /*cmd*/,
+//    //         const QString & params, const QString & /*sessionId*/) -> PBMSharedPtr {
 
-    addCommandCallback( "inputEvent", [=] (const QString & /*cmd*/,
-    		const QString & params, const QString & /*sessionId*/) ->QString {
+//    //     CARTA::FileInfo* fileInfo = new CARTA::FileInfo();
+//    //     fileInfo->set_name("test");
+//    //     fileInfo->set_type()
 
-    	QJsonDocument doc = QJsonDocument::fromJson( params.toLatin1() );
-    	if ( doc.isObject() ) {
-    		InputEvent ev( doc.object() );
-    		_onInputEvent( ev );
-    	}
-    	else {
-    		qDebug() << "Input event doc not an object";
-    	}
-        return m_stateMouse.toString();
-    	// return "";
-    });
+//    //     std::shared_ptr<CARTA::OpenFileAck> ack(new CARAT::OpenFileAck());
+//    //     ack->set_success(true);
+//    //     ack->set_allocated_file_info(fileInfo);
+//    // });
 
-    addCommandCallback( CLOSE_IMAGE, [=] (const QString & /*cmd*/,
-                    const QString & params, const QString & /*sessionId*/) ->QString {
-        std::set<QString> keys = {IMAGE};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString imageId = dataValues[*keys.begin()];
-        QString result = closeImage( imageId );
-                return result;
-    });
+//    addCommandCallback( "hideImage", [=] (const QString & /*cmd*/,
+//                        const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = {Util::ID};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString idStr = dataValues[*keys.begin()];
+//        QString result = setImageVisibility( /*imageIndex*/idStr, false );
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
+
+//    addCommandCallback( "moveLayers", [=] (const QString & /*cmd*/,
+//                                    const QString & params, const QString & /*sessionId*/) -> QString {
+//                std::set<QString> keys = {"moveDown"};
+//                std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//                QString moveDownStr = dataValues[*keys.begin()];
+//                bool validBool = false;
+//                bool moveDown = Util::toBool( moveDownStr, &validBool );
+//                QString result;
+//                if ( validBool ){
+//                    result = moveSelectedLayers( moveDown );
+//                }
+//                else {
+//                    result = "Whether to move up or down selected layers must be true/false: "+params;
+//                }
+//                Util::commandPostProcess( result );
+//                return result;
+//            });
+
+//    addCommandCallback( "setGroup", [=] (const QString & /*cmd*/,
+//                                const QString & params, const QString & /*sessionId*/) -> QString {
+//            std::set<QString> keys = {Layer::GROUP};
+//            std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//            QString groupSelects = dataValues[*keys.begin()];
+//            bool validBool = false;
+//            bool group = Util::toBool( groupSelects, &validBool );
+//            QString result;
+//            if ( validBool ){
+//                result = setSelectedLayersGrouped( group );
+//            }
+//            else {
+//                result = "Grouping layers must be true/false: "+params;
+//            }
+//            Util::commandPostProcess( result );
+//            return result;
+//        });
+
+//    addCommandCallback( "showImage", [=] (const QString & /*cmd*/,
+//                            const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = {Util::ID};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString idStr = dataValues[*keys.begin()];
+//        QString result = setImageVisibility( idStr, true );
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
 
 
-    addCommandCallback( Util::ZOOM, [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
-        bool error = false;
-        auto vals = Util::string2VectorDouble( params, &error );
-        if ( vals.size() > 2 ) {
-            double centerX = vals[0];
-            double centerY = vals[1];
-            double z = vals[2];
-            updatePanZoom( centerX, centerY, z );
-        }
-        return "";
-    });
 
-    addCommandCallback( "regionZoom", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
-        std::vector<std::shared_ptr<Region>> regions = m_regionControls->getRegions();
-        std::shared_ptr<DataSource> dataSource = this->getDataSource();
-        std::shared_ptr<Carta::Core::ImageRenderService::Service> imageService = dataSource->_getRenderer();
-        QJsonArray array;
-        for(int i = 0; i < regions.size(); i++) {
-            QJsonObject json = regions[i]->toJSON();
-            qreal x = json.value("x").toDouble();
-            qreal y = json.value("y").toDouble();
-            qreal width = json.value("width").toDouble();
-            qreal height = json.value("height").toDouble();
-            QPointF pt;
-            pt.setX(x - (width / 2));
-            pt.setY(y + (height / 2));
-            QPointF topLeft = imageService->img2screen(pt);
-            pt.setX(x + (width / 2));
-            QPointF topRight = imageService->img2screen(pt);
-            int w = static_cast<int>(topRight.x() - topLeft.x() + 0.5);
-            pt.setX(x - (width / 2));
-            pt.setY(y - (height / 2));
-            QPointF bottomLeft = imageService->img2screen(pt);
-            int h = static_cast<int>(bottomLeft.y() - topLeft.y() + 0.5);
-            QString str = "";
-            QJsonObject screenJson;
-            screenJson.insert("x", static_cast<int>(topLeft.x() + 0.5));
-            screenJson.insert("y", static_cast<int>(topLeft.y() + 0.5));
-            screenJson.insert("width", w);
-            screenJson.insert("height", h);
-            array.insert(i, QJsonValue(screenJson));
-        }
-        QString value = "";
-        QJsonDocument doc(array);
-        value = QString(doc.toJson());
-        return value;
-    });
+//    //Listen for updates to the clip and reload the frame.
+//    addCommandCallback( "setClipValue", [=] (const QString & /*cmd*/,
+//                const QString & params, const QString & /*sessionId*/) -> QString {
+//        QString result;
+//        std::set<QString> keys = {"clipValue"};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        bool validClip = false;
+//        QString clipKey = *keys.begin();
+//        QString clipWithoutPercent = dataValues[clipKey].remove("%");
+//        double clipVal = dataValues[clipKey].toDouble(&validClip);
+//        if ( validClip ){
+//            result = setClipValue( clipVal );
+//        }
+//        else {
+//            result = "Invalid clip value: "+params;
+//        }
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
 
-    addCommandCallback( "getDataGridState", [=] (const QString & /*cmd*/,
-            const QString & /*params*/, const QString & /*sessionId*/) ->QString {
-        Carta::State::StateInterface dataGridState = m_stack->_getDataGridState();
-        QString result = dataGridState.toString();
-        return result;
-    });
+//    addCommandCallback( "setAutoClip", [=] (const QString & /*cmd*/,
+//                    const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = {"autoClip"};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString clipKey = *keys.begin();
+//        bool validBool = false;
+//        bool autoClip = Util::toBool( dataValues[clipKey], &validBool );
+//        QString result;
+//        if ( validBool ){
+//            setAutoClip( autoClip );
+//        }
+//        else {
+//            result = "Auto clip must be true/false: "+params;
+//        }
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
 
-    addCommandCallback( "newzoom", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
-        bool error = false;
-        auto vals = Util::string2VectorDouble( params, &error );
-        if ( vals.size() > 0 ) {
+//    addCommandCallback( "setPanZoomAll", [=] (const QString & /*cmd*/,
+//                        const QString & params, const QString & /*sessionId*/) -> QString {
+//            std::set<QString> keys = {"panZoomAll"};
+//            std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//            QString panZoomKey = *keys.begin();
+//            bool validBool = false;
+//            bool panZoomAll = Util::toBool( dataValues[panZoomKey], &validBool );
+//            QString result;
+//            if ( validBool ){
+//                setPanZoomAll( panZoomAll );
+//            }
+//            else {
+//                result = "Pan/Zoom All must be true/false: "+params;
+//            }
+//            Util::commandPostProcess( result );
+//            return result;
+//        });
+
+//    /*QString pointerPath= UtilState::getLookup( getPath(), UtilState::getLookup( Util::VIEW, Util::POINTER_MOVE));
+//    addStateCallback( pointerPath, [=] ( const QString& path, const QString& value ) {
+//        QStringList mouseList = value.split( " ");
+//        if ( mouseList.size() == 2 ){
+//            bool validX = false;
+//            int mouseX = mouseList[0].toInt( &validX );
+//            bool validY = false;
+//            int mouseY = mouseList[1].toInt( &validY );
+//            if ( validX && validY ){
+//                _updateCursor( mouseX, mouseY );
+//                emit zoomChanged();
+//            }
+//        }
+//    });*/
+
+//    addCommandCallback( "inputEvent", [=] (const QString & /*cmd*/,
+//    		const QString & params, const QString & /*sessionId*/) ->QString {
+
+//    	QJsonDocument doc = QJsonDocument::fromJson( params.toLatin1() );
+//    	if ( doc.isObject() ) {
+//    		InputEvent ev( doc.object() );
+//    		_onInputEvent( ev );
+//    	}
+//    	else {
+//    		qDebug() << "Input event doc not an object";
+//    	}
+//        return m_stateMouse.toString();
+//    	// return "";
+//    });
+
+//    addCommandCallback( CLOSE_IMAGE, [=] (const QString & /*cmd*/,
+//                    const QString & params, const QString & /*sessionId*/) ->QString {
+//        std::set<QString> keys = {IMAGE};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString imageId = dataValues[*keys.begin()];
+//        QString result = closeImage( imageId );
+//                return result;
+//    });
+
+
+//    addCommandCallback( Util::ZOOM, [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) ->QString {
+//        bool error = false;
+//        auto vals = Util::string2VectorDouble( params, &error );
+//        if ( vals.size() > 2 ) {
 //            double centerX = vals[0];
 //            double centerY = vals[1];
-            double z = vals[0];
-
-            // updateZoom( centerX, centerY, z );
-            updateZoom(z);
-
-            // original it is used by Python Client, use for new CARTA zoom in/out temporarily
-            // setZoomLevel(z);
-        }
-        return "";
-    });
-
-    addCommandCallback( "getStackData", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
-
-        if ( m_stack != nullptr ){
-            QString ttt= m_stack->getStateString();
-            return m_stack->getStateString();
-        }
-
-        return "";
-    });
-
-    // unused
-    addCommandCallback( "setPanAndZoomLevel", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
-        bool error = false;
-        auto vals = Util::string2VectorDouble( params, &error );
-        if ( vals.size() > 2 ) {
-            double centerX = vals[0];
-            double centerY = vals[1];
-            double level = vals[2];
-            double layerId = vals[3];
-            updatePanZoomLevelJS( centerX, centerY, level, layerId );
-        }
-        return "";
-    });
-
-    addCommandCallback( "setZoomLevel", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
-        bool error = false;
-        auto vals = Util::string2VectorDouble( params, &error );
-        if ( vals.size() > 0 ) {
-            double z = vals[0];
-            double layerId = vals[1];
-            setZoomLevelJS(z, layerId);
-        }
-        return "";
-    });
-
-    addCommandCallback( "registerContourControls", [=] (const QString & /*cmd*/,
-                            const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-        QString result;
-        if ( m_contourControls.get() != nullptr ){
-            result = m_contourControls->getPath();
-        }
-        return result;
-    });
-
-    addCommandCallback( "registerStack", [=] (const QString & /*cmd*/,
-                                const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-            QString result;
-            if ( m_stack.get() != nullptr ){
-                result = m_stack->getPath();
-            }
-            return result;
-        });
-
-    addCommandCallback( "registerGridControls", [=] (const QString & /*cmd*/,
-                        const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-        QString result;
-        // if ( m_gridControls.get() != nullptr ){
-        //     result = m_gridControls->getPath();
-        // }
-        return result;
-    });
-
-    addCommandCallback( "registerPreferences", [=] (const QString & /*cmd*/,
-                            const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-        QString result = _getPreferencesId();
-        return result;
-   });
-
-    addCommandCallback( "registerRegionControls", [=] (const QString & /*cmd*/,
-                               const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-           QString result = _getRegionControlsId();
-           return result;
-      });
-
-
-    addCommandCallback( "resetPan", [=] (const QString & /*cmd*/,
-                            const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-        QString result;
-        resetPan();
-        return result;
-    });
-
-
-    addCommandCallback( "resetZoom", [=] (const QString & /*cmd*/,
-                        const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-        QString result;
-        resetZoom();
-        return result;
-    });
-
-    addCommandCallback( "setLayerName", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = {Util::ID,Util::NAME};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString result = setLayerName( dataValues[Util::ID], dataValues[Util::NAME] );
-        Util::commandPostProcess( result );
-        return result;
-    });
-
-
-    addCommandCallback( "setLayersSelected", [=] (const QString & /*cmd*/,
-                        const QString & params, const QString & /*sessionId*/) -> QString {
-        QString result;
-        QStringList names = params.split(";");
-        if ( names.size() == 0 ){
-            result = "Please specify the layers to select.";
-        }
-        else {
-            result = setLayersSelected( names );
-        }
-        Util::commandPostProcess( result );
-        return result;
-    });
-
-    addCommandCallback( "saveImage", [=] (const QString & /*cmd*/,
-                    const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = {DATA_PATH};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString result = saveImage( dataValues[DATA_PATH]);
-        Util::commandPostProcess( result );
-        return result;
-    });
-
-    addCommandCallback( "setMaskColor", [=] (const QString & /*cmd*/,
-                                const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = {Util::ID, Util::RED, Util::GREEN, Util::BLUE};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString result;
-        QString id = dataValues[Util::ID];
-        QString redStr = dataValues[Util::RED];
-        bool validRed = false;
-        int redAmount = redStr.toInt( &validRed );
-        QString greenStr = dataValues[Util::GREEN];
-        bool validGreen = false;
-        int greenAmount = greenStr.toInt( &validGreen );
-        QString blueStr = dataValues[Util::BLUE];
-        bool validBlue = false;
-        int blueAmount = blueStr.toInt( &validBlue );
-        if ( validRed && validGreen && validBlue ){
-            QStringList errorList = setMaskColor( id, redAmount, greenAmount, blueAmount );
-            result = errorList.join(";");
-        }
-        else {
-            result = "Invalid mask color(s): "+params;
-        }
-
-        Util::commandPostProcess( result );
-        return result;
-    });
-
-    addCommandCallback( "setMaskAlpha", [=] (const QString & /*cmd*/,
-                                    const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = { Util::ID, Util::ALPHA };
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString result;
-        QString idStr = dataValues[Util::ID];
-        QString alphaStr = dataValues[Util::ALPHA];
-        bool validAlpha = false;
-        int alphaAmount = alphaStr.toInt( &validAlpha );
-        if ( validAlpha ){
-            result = setMaskAlpha( idStr, alphaAmount );
-        }
-        else {
-            result = "Invalid mask opacity: "+params;
-        }
-        Util::commandPostProcess( result );
-        return result;
-    });
-
-    addCommandCallback( "setStackSelectAuto", [=] (const QString & /*cmd*/,
-                       const QString & params, const QString & /*sessionId*/) -> QString {
-       std::set<QString> keys = {STACK_SELECT_AUTO};
-       std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-       QString autoModeStr = dataValues[STACK_SELECT_AUTO];
-       bool validBool = false;
-       bool autoSelect = Util::toBool( autoModeStr, &validBool );
-       QString result;
-       if ( validBool ){
-           setStackSelectAuto( autoSelect );
-       }
-       else {
-           result = "Please specify true/false when setting whether stack selection should be automatic: "+autoModeStr;
-       }
-       Util::commandPostProcess( result );
-       return result;
-   });
-
-    addCommandCallback( "setCompositionMode", [=] (const QString & /*cmd*/,
-                            const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = {Util::ID, LayerGroup::COMPOSITION_MODE};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString compMode = dataValues[LayerGroup::COMPOSITION_MODE];
-        QString idStr = dataValues[Util::ID];
-        QString result = setCompositionMode( idStr, compMode );
-        Util::commandPostProcess( result );
-        return result;
-    });
-
-    addCommandCallback( "setRegionType", [=] (const QString & /*cmd*/,
-                                       const QString & params, const QString & /*sessionId*/) -> QString {
-               std::set<QString> keys = {Util::TYPE};
-               std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-               QString shape = dataValues[Util::TYPE];
-               QString result = m_regionControls->setRegionCreateType( shape );
-               return result;
-           });
-
-    addCommandCallback( "setTabIndex", [=] (const QString & /*cmd*/,
-                const QString & params, const QString & /*sessionId*/) -> QString {
-        QString result;
-        std::set<QString> keys = {Util::TAB_INDEX};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString tabIndexStr = dataValues[Util::TAB_INDEX];
-        bool validIndex = false;
-        int tabIndex = tabIndexStr.toInt( &validIndex );
-        if ( validIndex ){
-            result = setTabIndex( tabIndex );
-        }
-        else {
-            result = "Please check that the tab index is a number: " + params;
-        }
-        Util::commandPostProcess( result );
-        return result;
-    });
-
-
-
-////////// Copy the callback functions in gridcontrol here. A note for unfinished commands.
-
-    // addCommandCallback( "setApplyAll", [=] (const QString & /*cmd*/,
-    //                const QString & params, const QString & /*sessionId*/) -> QString {
-    //            QString result;
-    //            std::set<QString> keys = {ALL};
-    //            std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //            QString applyAllStr = dataValues[ALL];
-    //            bool validBool = false;
-    //            bool applyAll = Util::toBool( applyAllStr, &validBool );
-    //            if ( validBool ){
-    //                setApplyAll( applyAll  );
-    //            }
-    //            else {
-    //                result = "Whether or not to apply grid changes to all images must be true/false:"+params;
-    //            }
-    //            Util::commandPostProcess( result );
-    //            return result;
-    //        });
-    //
-    //
-    // addCommandCallback( "setAxesColor", [=] (const QString & /*cmd*/,
-    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
-    //     int redAmount = 0;
-    //     int greenAmount = 0;
-    //     int blueAmount = 0;
-    //     QStringList result = _parseColorParams( params, "Axes", &redAmount, &greenAmount, &blueAmount);
-    //     if ( result.size() == 0 ){
-    //         result = setAxesColor( redAmount, greenAmount, blueAmount );
-    //     }
-    //     QString errors;
-    //     if ( result.size() > 0 ){
-    //         errors = result.join( ",");
-    //     }
-    //     Util::commandPostProcess( errors );
-    //     return errors;
-    // });
-    //
-    addCommandCallback( "setAxesThickness", [=] (const QString & /*cmd*/,
-                                    const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::AXES_WIDTH;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setAxesTransparency", [=] (const QString & /*cmd*/,
-                                    const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::AXES_ALPHA;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setAxisX", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
-
-        QString result = m_stack->_setAxis( AxisMapper::AXIS_X, params );
-        return result;
-    });
-
-    addCommandCallback( "setAxisY", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
-
-        QString result = m_stack->_setAxis( AxisMapper::AXIS_Y, params );
-        return result;
-    });
-
-    addCommandCallback( "setCoordinateSystem", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString result = m_stack->_setCoordinateSystem( params );
-        return result;
-    });
-
-     addCommandCallback( "setGridLabelFormat", [=] (const QString & /*cmd*/,
-                         const QString & params, const QString & /*sessionId*/) -> QString {
-        std::set<QString> keys = {DataGrid::FORMAT, DataGrid::LABEL_SIDE};
-        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        QString format = dataValues[DataGrid::FORMAT];
-                     //Because the map expects colons and the label format has colons,
-                     //the format colons are replaced with a - before sending from the
-                     //client and the server must restore the colons.
-        format = format.replace( "-", ":");
-        QString labelSide = dataValues[DataGrid::LABEL_SIDE];
-//                     QString result = setLabelFormat( labelSide, format );
-//                     Util::commandPostProcess( result );
-        QString directionLookup = Carta::State::UtilState::getLookup( DataGrid::LABEL_FORMAT, labelSide);
-        QString directionFormatLookup = Carta::State::UtilState::getLookup( directionLookup, DataGrid::FORMAT );
-        LabelFormats *m_formats = Util::findSingletonObject<LabelFormats>();
-        QString actualFormat = m_formats->getFormat(format);
-        QString result = m_stack->_setDataGridState(directionFormatLookup, actualFormat);
-        QString oppositeSide = m_formats->getOppositeSide(labelSide);
-        QString dLookup = Carta::State::UtilState::getLookup( DataGrid::LABEL_FORMAT, oppositeSide );
-        QString dFormatLookup = Carta::State::UtilState::getLookup( dLookup, DataGrid::FORMAT );
-        result = m_stack->_setDataGridState(dFormatLookup, LabelFormats::FORMAT_NONE);
-        return result;
-    });
-
-    // addCommandCallback( "setGridColor", [=] (const QString & /*cmd*/,
-    //                                     const QString & params, const QString & /*sessionId*/) -> QString {
-    //         int redAmount = 0;
-    //         int greenAmount = 0;
-    //         int blueAmount = 0;
-    //         QStringList result = _parseColorParams( params, DataGrid::GRID, &redAmount, &greenAmount, &blueAmount);
-    //         if ( result.size() == 0 ){
-    //             result = setGridColor( redAmount, greenAmount, blueAmount );
-    //         }
-    //         QString errors;
-    //         if ( result.size() > 0 ){
-    //             errors = result.join( ",");
-    //         }
-    //         Util::commandPostProcess( errors );
-    //         return errors;
-    //     });
-    //
-    addCommandCallback( "setFontFamily", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        // TODO: the function is unfinished
-        QString stateName = DataGrid::FONT_FAMILY;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setFontSize", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::FONT_SIZE;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setGridThickness", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::GRID_WIDTH;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setGridSpacing", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::SPACING;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setGridTransparency", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::GRID_ALPHA;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setLabelDecimals", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::LABEL_DECIMAL_PLACES;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    // addCommandCallback( "setLabelColor", [=] (const QString & /*cmd*/,
-    //                             const QString & params, const QString & /*sessionId*/) -> QString {
-    //         int redAmount = 0;
-    //         int greenAmount = 0;
-    //         int blueAmount = 0;
-    //         QStringList result = _parseColorParams( params, "Label", &redAmount, &greenAmount, &blueAmount);
-    //         if ( result.size() == 0 ){
-    //             result = setLabelColor( redAmount, greenAmount, blueAmount );
-    //         }
-    //         QString errors;
-    //         if ( result.size() > 0 ){
-    //             errors = result.join( ",");
-    //         }
-    //         Util::commandPostProcess( errors );
-    //         return errors;
-    //     });
-    //
-    addCommandCallback( "setShowAxis", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::SHOW_AXIS;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setShowCoordinateSystem", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::SHOW_COORDS;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setShowDefaultCoordinateSystem", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::SHOW_DEFAULT_COORDS;
-        QString result = m_stack->_setDataGridState( stateName, params );
-
-        Carta::State::StateInterface stackDataGridState = m_stack->_getDataGridState();
-        bool useDefault = stackDataGridState.getValue<bool>( DataGrid::SHOW_DEFAULT_COORDS );
-        if ( useDefault ){
-            CoordinateSystems* m_coords = Util::findSingletonObject<CoordinateSystems>();
-            QString defaultName = m_coords->getDefault();
-            result = m_stack->_setCoordinateSystem( defaultName );
-        }
-        return result;
-    });
-
-    addCommandCallback( "setShowGridLines", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::SHOW_GRID_LINES;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setShowInternalLabels", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::SHOW_INTERNAL_LABELS;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setShowTicks", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::SHOW_TICKS;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-    //
-    // addCommandCallback( "setShowStatistics", [=] (const QString & /*cmd*/,
-    //                     const QString & params, const QString & /*sessionId*/) -> QString {
-    //                 QString result;
-    //                 std::set<QString> keys = {DataGrid::SHOW_STATISTICS};
-    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //                 QString showStatisticsStr = dataValues[DataGrid::SHOW_STATISTICS];
-    //                 bool validBool = false;
-    //                 bool showStatistics = Util::toBool( showStatisticsStr, &validBool );
-    //                 if ( validBool ){
-    //                     result = setShowStatistics( showStatistics  );
-    //                 }
-    //                 else {
-    //                     result = "Making statistics visible/invisible must be true/false:"+params;
-    //                 }
-    //                 Util::commandPostProcess( result );
-    //                 return result;
-    //             });
-    //
-    // addCommandCallback( "setTickColor", [=] (const QString & /*cmd*/,
-    //                                        const QString & params, const QString & /*sessionId*/) -> QString {
-    //            int redAmount = 0;
-    //            int greenAmount = 0;
-    //            int blueAmount = 0;
-    //            QStringList result = _parseColorParams( params, DataGrid::TICK, &redAmount, &greenAmount, &blueAmount);
-    //            if ( result.size() == 0 ){
-    //                result = setTickColor( redAmount, greenAmount, blueAmount );
-    //            }
-    //            QString errors;
-    //            if ( result.size() > 0 ){
-    //                errors = result.join( ",");
-    //            }
-    //            Util::commandPostProcess( errors );
-    //            return errors;
-    //        });
-    //
-    addCommandCallback( "setTickLength", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::TICK_LENGTH;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setTickThickness", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::TICK_WIDTH;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-
-    addCommandCallback( "setTickTransparency", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) -> QString {
-
-        QString stateName = DataGrid::TICK_ALPHA;
-        QString result = m_stack->_setDataGridState( stateName, params );
-        return result;
-    });
-    //
-    // addCommandCallback( "setTheme", [=] (const QString & /*cmd*/,
-    //                         const QString & params, const QString & /*sessionId*/) -> QString {
-    //                     std::set<QString> keys = {DataGrid::THEME};
-    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //                     QString themeStr = dataValues[DataGrid::THEME];
-    //                     QString result = setTheme( themeStr );
-    //                     Util::commandPostProcess( result );
-    //                     return result;
-    //                 });
-    addCommandCallback( "getColormaps", [=] (const QString & /*cmd*/,
-                        const QString & params, const QString & /*sessionId*/) -> QString {
-        Colormaps* colormaps = Util::findSingletonObject<Colormaps>();
-        QString result = colormaps->getColorMaps().join(",");
-        return result;
-    });
-}
+//            double z = vals[2];
+//            updatePanZoom( centerX, centerY, z );
+//        }
+//        return "";
+//    });
+
+//    addCommandCallback( "regionZoom", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) ->QString {
+//        std::vector<std::shared_ptr<Region>> regions = m_regionControls->getRegions();
+//        std::shared_ptr<DataSource> dataSource = this->getDataSource();
+//        std::shared_ptr<Carta::Core::ImageRenderService::Service> imageService = dataSource->_getRenderer();
+//        QJsonArray array;
+//        for(int i = 0; i < regions.size(); i++) {
+//            QJsonObject json = regions[i]->toJSON();
+//            qreal x = json.value("x").toDouble();
+//            qreal y = json.value("y").toDouble();
+//            qreal width = json.value("width").toDouble();
+//            qreal height = json.value("height").toDouble();
+//            QPointF pt;
+//            pt.setX(x - (width / 2));
+//            pt.setY(y + (height / 2));
+//            QPointF topLeft = imageService->img2screen(pt);
+//            pt.setX(x + (width / 2));
+//            QPointF topRight = imageService->img2screen(pt);
+//            int w = static_cast<int>(topRight.x() - topLeft.x() + 0.5);
+//            pt.setX(x - (width / 2));
+//            pt.setY(y - (height / 2));
+//            QPointF bottomLeft = imageService->img2screen(pt);
+//            int h = static_cast<int>(bottomLeft.y() - topLeft.y() + 0.5);
+//            QString str = "";
+//            QJsonObject screenJson;
+//            screenJson.insert("x", static_cast<int>(topLeft.x() + 0.5));
+//            screenJson.insert("y", static_cast<int>(topLeft.y() + 0.5));
+//            screenJson.insert("width", w);
+//            screenJson.insert("height", h);
+//            array.insert(i, QJsonValue(screenJson));
+//        }
+//        QString value = "";
+//        QJsonDocument doc(array);
+//        value = QString(doc.toJson());
+//        return value;
+//    });
+
+//    addCommandCallback( "getDataGridState", [=] (const QString & /*cmd*/,
+//            const QString & /*params*/, const QString & /*sessionId*/) ->QString {
+//        Carta::State::StateInterface dataGridState = m_stack->_getDataGridState();
+//        QString result = dataGridState.toString();
+//        return result;
+//    });
+
+//    addCommandCallback( "newzoom", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) ->QString {
+//        bool error = false;
+//        auto vals = Util::string2VectorDouble( params, &error );
+//        if ( vals.size() > 0 ) {
+////            double centerX = vals[0];
+////            double centerY = vals[1];
+//            double z = vals[0];
+
+//            // updateZoom( centerX, centerY, z );
+//            updateZoom(z);
+
+//            // original it is used by Python Client, use for new CARTA zoom in/out temporarily
+//            // setZoomLevel(z);
+//        }
+//        return "";
+//    });
+
+//    addCommandCallback( "getStackData", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) ->QString {
+
+//        if ( m_stack != nullptr ){
+//            QString ttt= m_stack->getStateString();
+//            return m_stack->getStateString();
+//        }
+
+//        return "";
+//    });
+
+//    // unused
+//    addCommandCallback( "setPanAndZoomLevel", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) ->QString {
+//        bool error = false;
+//        auto vals = Util::string2VectorDouble( params, &error );
+//        if ( vals.size() > 2 ) {
+//            double centerX = vals[0];
+//            double centerY = vals[1];
+//            double level = vals[2];
+//            double layerId = vals[3];
+//            updatePanZoomLevelJS( centerX, centerY, level, layerId );
+//        }
+//        return "";
+//    });
+
+//    addCommandCallback( "setZoomLevel", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) ->QString {
+//        bool error = false;
+//        auto vals = Util::string2VectorDouble( params, &error );
+//        if ( vals.size() > 0 ) {
+//            double z = vals[0];
+//            double layerId = vals[1];
+//            setZoomLevelJS(z, layerId);
+//        }
+//        return "";
+//    });
+
+//    addCommandCallback( "registerContourControls", [=] (const QString & /*cmd*/,
+//                            const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+//        QString result;
+//        if ( m_contourControls.get() != nullptr ){
+//            result = m_contourControls->getPath();
+//        }
+//        return result;
+//    });
+
+//    addCommandCallback( "registerStack", [=] (const QString & /*cmd*/,
+//                                const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+//            QString result;
+//            if ( m_stack.get() != nullptr ){
+//                result = m_stack->getPath();
+//            }
+//            return result;
+//        });
+
+//    addCommandCallback( "registerGridControls", [=] (const QString & /*cmd*/,
+//                        const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+//        QString result;
+//        // if ( m_gridControls.get() != nullptr ){
+//        //     result = m_gridControls->getPath();
+//        // }
+//        return result;
+//    });
+
+//    addCommandCallback( "registerPreferences", [=] (const QString & /*cmd*/,
+//                            const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+//        QString result = _getPreferencesId();
+//        return result;
+//   });
+
+//    addCommandCallback( "registerRegionControls", [=] (const QString & /*cmd*/,
+//                               const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+//           QString result = _getRegionControlsId();
+//           return result;
+//      });
+
+
+//    addCommandCallback( "resetPan", [=] (const QString & /*cmd*/,
+//                            const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+//        QString result;
+//        resetPan();
+//        return result;
+//    });
+
+
+//    addCommandCallback( "resetZoom", [=] (const QString & /*cmd*/,
+//                        const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+//        QString result;
+//        resetZoom();
+//        return result;
+//    });
+
+//    addCommandCallback( "setLayerName", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = {Util::ID,Util::NAME};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString result = setLayerName( dataValues[Util::ID], dataValues[Util::NAME] );
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
+
+
+//    addCommandCallback( "setLayersSelected", [=] (const QString & /*cmd*/,
+//                        const QString & params, const QString & /*sessionId*/) -> QString {
+//        QString result;
+//        QStringList names = params.split(";");
+//        if ( names.size() == 0 ){
+//            result = "Please specify the layers to select.";
+//        }
+//        else {
+//            result = setLayersSelected( names );
+//        }
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
+
+//    addCommandCallback( "saveImage", [=] (const QString & /*cmd*/,
+//                    const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = {DATA_PATH};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString result = saveImage( dataValues[DATA_PATH]);
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
+
+//    addCommandCallback( "setMaskColor", [=] (const QString & /*cmd*/,
+//                                const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = {Util::ID, Util::RED, Util::GREEN, Util::BLUE};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString result;
+//        QString id = dataValues[Util::ID];
+//        QString redStr = dataValues[Util::RED];
+//        bool validRed = false;
+//        int redAmount = redStr.toInt( &validRed );
+//        QString greenStr = dataValues[Util::GREEN];
+//        bool validGreen = false;
+//        int greenAmount = greenStr.toInt( &validGreen );
+//        QString blueStr = dataValues[Util::BLUE];
+//        bool validBlue = false;
+//        int blueAmount = blueStr.toInt( &validBlue );
+//        if ( validRed && validGreen && validBlue ){
+//            QStringList errorList = setMaskColor( id, redAmount, greenAmount, blueAmount );
+//            result = errorList.join(";");
+//        }
+//        else {
+//            result = "Invalid mask color(s): "+params;
+//        }
+
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
+
+//    addCommandCallback( "setMaskAlpha", [=] (const QString & /*cmd*/,
+//                                    const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = { Util::ID, Util::ALPHA };
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString result;
+//        QString idStr = dataValues[Util::ID];
+//        QString alphaStr = dataValues[Util::ALPHA];
+//        bool validAlpha = false;
+//        int alphaAmount = alphaStr.toInt( &validAlpha );
+//        if ( validAlpha ){
+//            result = setMaskAlpha( idStr, alphaAmount );
+//        }
+//        else {
+//            result = "Invalid mask opacity: "+params;
+//        }
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
+
+//    addCommandCallback( "setStackSelectAuto", [=] (const QString & /*cmd*/,
+//                       const QString & params, const QString & /*sessionId*/) -> QString {
+//       std::set<QString> keys = {STACK_SELECT_AUTO};
+//       std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//       QString autoModeStr = dataValues[STACK_SELECT_AUTO];
+//       bool validBool = false;
+//       bool autoSelect = Util::toBool( autoModeStr, &validBool );
+//       QString result;
+//       if ( validBool ){
+//           setStackSelectAuto( autoSelect );
+//       }
+//       else {
+//           result = "Please specify true/false when setting whether stack selection should be automatic: "+autoModeStr;
+//       }
+//       Util::commandPostProcess( result );
+//       return result;
+//   });
+
+//    addCommandCallback( "setCompositionMode", [=] (const QString & /*cmd*/,
+//                            const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = {Util::ID, LayerGroup::COMPOSITION_MODE};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString compMode = dataValues[LayerGroup::COMPOSITION_MODE];
+//        QString idStr = dataValues[Util::ID];
+//        QString result = setCompositionMode( idStr, compMode );
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
+
+//    addCommandCallback( "setRegionType", [=] (const QString & /*cmd*/,
+//                                       const QString & params, const QString & /*sessionId*/) -> QString {
+//               std::set<QString> keys = {Util::TYPE};
+//               std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//               QString shape = dataValues[Util::TYPE];
+//               QString result = m_regionControls->setRegionCreateType( shape );
+//               return result;
+//           });
+
+//    addCommandCallback( "setTabIndex", [=] (const QString & /*cmd*/,
+//                const QString & params, const QString & /*sessionId*/) -> QString {
+//        QString result;
+//        std::set<QString> keys = {Util::TAB_INDEX};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString tabIndexStr = dataValues[Util::TAB_INDEX];
+//        bool validIndex = false;
+//        int tabIndex = tabIndexStr.toInt( &validIndex );
+//        if ( validIndex ){
+//            result = setTabIndex( tabIndex );
+//        }
+//        else {
+//            result = "Please check that the tab index is a number: " + params;
+//        }
+//        Util::commandPostProcess( result );
+//        return result;
+//    });
+
+
+
+//////////// Copy the callback functions in gridcontrol here. A note for unfinished commands.
+
+//    // addCommandCallback( "setApplyAll", [=] (const QString & /*cmd*/,
+//    //                const QString & params, const QString & /*sessionId*/) -> QString {
+//    //            QString result;
+//    //            std::set<QString> keys = {ALL};
+//    //            std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//    //            QString applyAllStr = dataValues[ALL];
+//    //            bool validBool = false;
+//    //            bool applyAll = Util::toBool( applyAllStr, &validBool );
+//    //            if ( validBool ){
+//    //                setApplyAll( applyAll  );
+//    //            }
+//    //            else {
+//    //                result = "Whether or not to apply grid changes to all images must be true/false:"+params;
+//    //            }
+//    //            Util::commandPostProcess( result );
+//    //            return result;
+//    //        });
+//    //
+//    //
+//    // addCommandCallback( "setAxesColor", [=] (const QString & /*cmd*/,
+//    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
+//    //     int redAmount = 0;
+//    //     int greenAmount = 0;
+//    //     int blueAmount = 0;
+//    //     QStringList result = _parseColorParams( params, "Axes", &redAmount, &greenAmount, &blueAmount);
+//    //     if ( result.size() == 0 ){
+//    //         result = setAxesColor( redAmount, greenAmount, blueAmount );
+//    //     }
+//    //     QString errors;
+//    //     if ( result.size() > 0 ){
+//    //         errors = result.join( ",");
+//    //     }
+//    //     Util::commandPostProcess( errors );
+//    //     return errors;
+//    // });
+//    //
+//    addCommandCallback( "setAxesThickness", [=] (const QString & /*cmd*/,
+//                                    const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::AXES_WIDTH;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setAxesTransparency", [=] (const QString & /*cmd*/,
+//                                    const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::AXES_ALPHA;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setAxisX", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) ->QString {
+
+//        QString result = m_stack->_setAxis( AxisMapper::AXIS_X, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setAxisY", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) ->QString {
+
+//        QString result = m_stack->_setAxis( AxisMapper::AXIS_Y, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setCoordinateSystem", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString result = m_stack->_setCoordinateSystem( params );
+//        return result;
+//    });
+
+//     addCommandCallback( "setGridLabelFormat", [=] (const QString & /*cmd*/,
+//                         const QString & params, const QString & /*sessionId*/) -> QString {
+//        std::set<QString> keys = {DataGrid::FORMAT, DataGrid::LABEL_SIDE};
+//        std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//        QString format = dataValues[DataGrid::FORMAT];
+//                     //Because the map expects colons and the label format has colons,
+//                     //the format colons are replaced with a - before sending from the
+//                     //client and the server must restore the colons.
+//        format = format.replace( "-", ":");
+//        QString labelSide = dataValues[DataGrid::LABEL_SIDE];
+////                     QString result = setLabelFormat( labelSide, format );
+////                     Util::commandPostProcess( result );
+//        QString directionLookup = Carta::State::UtilState::getLookup( DataGrid::LABEL_FORMAT, labelSide);
+//        QString directionFormatLookup = Carta::State::UtilState::getLookup( directionLookup, DataGrid::FORMAT );
+//        LabelFormats *m_formats = Util::findSingletonObject<LabelFormats>();
+//        QString actualFormat = m_formats->getFormat(format);
+//        QString result = m_stack->_setDataGridState(directionFormatLookup, actualFormat);
+//        QString oppositeSide = m_formats->getOppositeSide(labelSide);
+//        QString dLookup = Carta::State::UtilState::getLookup( DataGrid::LABEL_FORMAT, oppositeSide );
+//        QString dFormatLookup = Carta::State::UtilState::getLookup( dLookup, DataGrid::FORMAT );
+//        result = m_stack->_setDataGridState(dFormatLookup, LabelFormats::FORMAT_NONE);
+//        return result;
+//    });
+
+//    // addCommandCallback( "setGridColor", [=] (const QString & /*cmd*/,
+//    //                                     const QString & params, const QString & /*sessionId*/) -> QString {
+//    //         int redAmount = 0;
+//    //         int greenAmount = 0;
+//    //         int blueAmount = 0;
+//    //         QStringList result = _parseColorParams( params, DataGrid::GRID, &redAmount, &greenAmount, &blueAmount);
+//    //         if ( result.size() == 0 ){
+//    //             result = setGridColor( redAmount, greenAmount, blueAmount );
+//    //         }
+//    //         QString errors;
+//    //         if ( result.size() > 0 ){
+//    //             errors = result.join( ",");
+//    //         }
+//    //         Util::commandPostProcess( errors );
+//    //         return errors;
+//    //     });
+//    //
+//    addCommandCallback( "setFontFamily", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        // TODO: the function is unfinished
+//        QString stateName = DataGrid::FONT_FAMILY;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setFontSize", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::FONT_SIZE;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setGridThickness", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::GRID_WIDTH;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setGridSpacing", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::SPACING;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setGridTransparency", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::GRID_ALPHA;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setLabelDecimals", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::LABEL_DECIMAL_PLACES;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    // addCommandCallback( "setLabelColor", [=] (const QString & /*cmd*/,
+//    //                             const QString & params, const QString & /*sessionId*/) -> QString {
+//    //         int redAmount = 0;
+//    //         int greenAmount = 0;
+//    //         int blueAmount = 0;
+//    //         QStringList result = _parseColorParams( params, "Label", &redAmount, &greenAmount, &blueAmount);
+//    //         if ( result.size() == 0 ){
+//    //             result = setLabelColor( redAmount, greenAmount, blueAmount );
+//    //         }
+//    //         QString errors;
+//    //         if ( result.size() > 0 ){
+//    //             errors = result.join( ",");
+//    //         }
+//    //         Util::commandPostProcess( errors );
+//    //         return errors;
+//    //     });
+//    //
+//    addCommandCallback( "setShowAxis", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::SHOW_AXIS;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setShowCoordinateSystem", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::SHOW_COORDS;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setShowDefaultCoordinateSystem", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::SHOW_DEFAULT_COORDS;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+
+//        Carta::State::StateInterface stackDataGridState = m_stack->_getDataGridState();
+//        bool useDefault = stackDataGridState.getValue<bool>( DataGrid::SHOW_DEFAULT_COORDS );
+//        if ( useDefault ){
+//            CoordinateSystems* m_coords = Util::findSingletonObject<CoordinateSystems>();
+//            QString defaultName = m_coords->getDefault();
+//            result = m_stack->_setCoordinateSystem( defaultName );
+//        }
+//        return result;
+//    });
+
+//    addCommandCallback( "setShowGridLines", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::SHOW_GRID_LINES;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setShowInternalLabels", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::SHOW_INTERNAL_LABELS;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setShowTicks", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::SHOW_TICKS;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+//    //
+//    // addCommandCallback( "setShowStatistics", [=] (const QString & /*cmd*/,
+//    //                     const QString & params, const QString & /*sessionId*/) -> QString {
+//    //                 QString result;
+//    //                 std::set<QString> keys = {DataGrid::SHOW_STATISTICS};
+//    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//    //                 QString showStatisticsStr = dataValues[DataGrid::SHOW_STATISTICS];
+//    //                 bool validBool = false;
+//    //                 bool showStatistics = Util::toBool( showStatisticsStr, &validBool );
+//    //                 if ( validBool ){
+//    //                     result = setShowStatistics( showStatistics  );
+//    //                 }
+//    //                 else {
+//    //                     result = "Making statistics visible/invisible must be true/false:"+params;
+//    //                 }
+//    //                 Util::commandPostProcess( result );
+//    //                 return result;
+//    //             });
+//    //
+//    // addCommandCallback( "setTickColor", [=] (const QString & /*cmd*/,
+//    //                                        const QString & params, const QString & /*sessionId*/) -> QString {
+//    //            int redAmount = 0;
+//    //            int greenAmount = 0;
+//    //            int blueAmount = 0;
+//    //            QStringList result = _parseColorParams( params, DataGrid::TICK, &redAmount, &greenAmount, &blueAmount);
+//    //            if ( result.size() == 0 ){
+//    //                result = setTickColor( redAmount, greenAmount, blueAmount );
+//    //            }
+//    //            QString errors;
+//    //            if ( result.size() > 0 ){
+//    //                errors = result.join( ",");
+//    //            }
+//    //            Util::commandPostProcess( errors );
+//    //            return errors;
+//    //        });
+//    //
+//    addCommandCallback( "setTickLength", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::TICK_LENGTH;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setTickThickness", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::TICK_WIDTH;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+
+//    addCommandCallback( "setTickTransparency", [=] (const QString & /*cmd*/,
+//            const QString & params, const QString & /*sessionId*/) -> QString {
+
+//        QString stateName = DataGrid::TICK_ALPHA;
+//        QString result = m_stack->_setDataGridState( stateName, params );
+//        return result;
+//    });
+//    //
+//    // addCommandCallback( "setTheme", [=] (const QString & /*cmd*/,
+//    //                         const QString & params, const QString & /*sessionId*/) -> QString {
+//    //                     std::set<QString> keys = {DataGrid::THEME};
+//    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+//    //                     QString themeStr = dataValues[DataGrid::THEME];
+//    //                     QString result = setTheme( themeStr );
+//    //                     Util::commandPostProcess( result );
+//    //                     return result;
+//    //                 });
+//    addCommandCallback( "getColormaps", [=] (const QString & /*cmd*/,
+//                        const QString & params, const QString & /*sessionId*/) -> QString {
+//        Colormaps* colormaps = Util::findSingletonObject<Colormaps>();
+//        QString result = colormaps->getColorMaps().join(",");
+//        return result;
+//    });
+//}
 
 
 void Controller::_initializeState(){
@@ -1471,11 +1471,11 @@ void Controller::removeContourSet( std::shared_ptr<DataContours> contourSet ){
     m_stack->_removeContourSet( contourSet );
 }
 
-void Controller::_renderZoom( double factor ){
-    int mouseX = m_stateMouse.getValue<int>(ImageView::MOUSE_X );
-    int mouseY = m_stateMouse.getValue<int>(ImageView::MOUSE_Y );
-    m_stack->_renderZoom( mouseX, mouseY, factor  );
-}
+//void Controller::_renderZoom( double factor ){
+//    int mouseX = m_stateMouse.getValue<int>(ImageView::MOUSE_X );
+//    int mouseY = m_stateMouse.getValue<int>(ImageView::MOUSE_Y );
+//    m_stack->_renderZoom( mouseX, mouseY, factor  );
+//}
 
 void Controller::_renderContext( double zoomFactor ){
     m_stack->_renderContext( zoomFactor );
@@ -1633,10 +1633,10 @@ void Controller::recallClipValue() {
 // }
 
 
-void Controller::_setFrameAxis(int value, AxisInfo::KnownType axisType ) {
-    m_stack->_setFrameAxis( value, axisType );
-    _updateCursorText( true );
-}
+//void Controller::_setFrameAxis(int value, AxisInfo::KnownType axisType ) {
+//    m_stack->_setFrameAxis( value, axisType );
+//    _updateCursorText( true );
+//}
 
 void Controller::setFrameImage( int val) {
     if ( val < 0 ){
@@ -1788,23 +1788,23 @@ QString Controller::setCompositionMode( const QString& id, const QString& compMo
     return result;
 }
 
-QString Controller::setSelectedLayersGrouped( bool grouped ){
-    QString result;
-    bool operationPerformed = m_stack->_setLayersGrouped( grouped );
-    if ( operationPerformed ){
-        //Notify others there has been a change to the data.
-        emit dataChanged( this );
-    }
-    else {
-        if ( grouped ){
-            result = "The selected layer(s) could not be grouped.";
-        }
-        else {
-            result = "Unable to remove group.";
-        }
-    }
-    return result;
-}
+//QString Controller::setSelectedLayersGrouped( bool grouped ){
+//    QString result;
+//    bool operationPerformed = m_stack->_setLayersGrouped( grouped );
+//    if ( operationPerformed ){
+//        //Notify others there has been a change to the data.
+//        emit dataChanged( this );
+//    }
+//    else {
+//        if ( grouped ){
+//            result = "The selected layer(s) could not be grouped.";
+//        }
+//        else {
+//            result = "Unable to remove group.";
+//        }
+//    }
+//    return result;
+//}
 
 QString Controller::setTabIndex( int index ){
     QString result;
@@ -1839,41 +1839,41 @@ void Controller::setZoomLevelJS( double zoomFactor, double layerId ){
     m_stack->_setZoomLevelForLayerId( zoomFactor, layerId );
 }
 
-void Controller::_updateCursor( int mouseX, int mouseY ){
-    if ( m_stack->_getStackSize() == 0 ){
-        return;
-    }
+//void Controller::_updateCursor( int mouseX, int mouseY ){
+//    if ( m_stack->_getStackSize() == 0 ){
+//        return;
+//    }
 
-    int oldMouseX = m_stateMouse.getValue<int>( ImageView::MOUSE_X );
-    int oldMouseY = m_stateMouse.getValue<int>( ImageView::MOUSE_Y );
-    if ( oldMouseX != mouseX || oldMouseY != mouseY ){
-        m_stateMouse.setValue<int>( ImageView::MOUSE_X, mouseX);
-        m_stateMouse.setValue<int>( ImageView::MOUSE_Y, mouseY );
-        _updateCursorText( false );
-        m_stateMouse.flushState();
-    }
-}
+//    int oldMouseX = m_stateMouse.getValue<int>( ImageView::MOUSE_X );
+//    int oldMouseY = m_stateMouse.getValue<int>( ImageView::MOUSE_Y );
+//    if ( oldMouseX != mouseX || oldMouseY != mouseY ){
+//        m_stateMouse.setValue<int>( ImageView::MOUSE_X, mouseX);
+//        m_stateMouse.setValue<int>( ImageView::MOUSE_Y, mouseY );
+//        _updateCursorText( false );
+//        m_stateMouse.flushState();
+//    }
+//}
 
-void Controller::_updateCursorText(bool notifyClients ){
-    QString formattedCursor;
-    int mouseX = m_stateMouse.getValue<int>(ImageView::MOUSE_X );
-    int mouseY = m_stateMouse.getValue<int>(ImageView::MOUSE_Y );
+//void Controller::_updateCursorText(bool notifyClients ){
+//    QString formattedCursor;
+//    int mouseX = m_stateMouse.getValue<int>(ImageView::MOUSE_X );
+//    int mouseY = m_stateMouse.getValue<int>(ImageView::MOUSE_Y );
 
-    // get Quantile information and show them on the image viewer
-    double minPercent = m_state.getValue<double>(CLIP_VALUE_MIN);
-    double maxPercent = m_state.getValue<double>(CLIP_VALUE_MAX);
-    bool isAutoClip = m_state.getValue<bool>(AUTO_CLIP);
-    QString cursorText = m_stack->_getCursorText(isAutoClip, minPercent, maxPercent, mouseX, mouseY);
+//    // get Quantile information and show them on the image viewer
+//    double minPercent = m_state.getValue<double>(CLIP_VALUE_MIN);
+//    double maxPercent = m_state.getValue<double>(CLIP_VALUE_MAX);
+//    bool isAutoClip = m_state.getValue<bool>(AUTO_CLIP);
+//    QString cursorText = m_stack->_getCursorText(isAutoClip, minPercent, maxPercent, mouseX, mouseY);
 
-    if ( !cursorText.isEmpty()){
-        if ( cursorText != m_stateMouse.getValue<QString>(CURSOR)){
-            m_stateMouse.setValue<QString>( CURSOR, cursorText );
-            if ( notifyClients ){
-                m_stateMouse.flushState();
-            }
-        }
-    }
-}
+//    if ( !cursorText.isEmpty()){
+//        if ( cursorText != m_stateMouse.getValue<QString>(CURSOR)){
+//            m_stateMouse.setValue<QString>( CURSOR, cursorText );
+//            if ( notifyClients ){
+//                m_stateMouse.flushState();
+//            }
+//        }
+//    }
+//}
 
 
 // void Controller::_updateDisplayAxes(){
@@ -1890,18 +1890,18 @@ void Controller::_updateCursorText(bool notifyClients ){
 //     }
 // }
 
-void Controller::updatePanZoomLevelJS( double centerX, double centerY, double zoomLevel, double layerId ){
-    m_stack->_updatePanZoom( centerX, centerY, -1, false, zoomLevel, layerId);
-    emit contextChanged();
-    emit zoomChanged();
-}
+//void Controller::updatePanZoomLevelJS( double centerX, double centerY, double zoomLevel, double layerId ){
+//    m_stack->_updatePanZoom( centerX, centerY, -1, false, zoomLevel, layerId);
+//    emit contextChanged();
+//    emit zoomChanged();
+//}
 
-void Controller::updatePanZoom( double centerX, double centerY, double zoomFactor ){
-    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
-    m_stack->_updatePanZoom( centerX, centerY, zoomFactor, zoomPanAll, -1, -1);
-    emit contextChanged();
-    emit zoomChanged();
-}
+//void Controller::updatePanZoom( double centerX, double centerY, double zoomFactor ){
+//    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
+//    m_stack->_updatePanZoom( centerX, centerY, zoomFactor, zoomPanAll, -1, -1);
+//    emit contextChanged();
+//    emit zoomChanged();
+//}
 
 void Controller::updateZoom(double zoomFactor){
     bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
@@ -1911,13 +1911,13 @@ void Controller::updateZoom(double zoomFactor){
 }
 
 
-void Controller::updatePan( double centerX , double centerY){
-    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
-    m_stack->_updatePan( centerX, centerY, zoomPanAll );
-    _updateCursorText( true );
-    emit contextChanged();
-    emit zoomChanged();
-}
+//void Controller::updatePan( double centerX , double centerY){
+//    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
+//    m_stack->_updatePan( centerX, centerY, zoomPanAll );
+//    _updateCursorText( true );
+//    emit contextChanged();
+//    emit zoomChanged();
+//}
 
 
 

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -198,7 +198,7 @@ public:
      * @param valid - set to false if the returned point is invalid.
      * @return - the image coordinates of the point under the cursor.
      */
-    QPointF getImagePt( bool* valid ) const;
+//    QPointF getImagePt( bool* valid ) const;
 
     /**
      * Return a list of images that have been loaded.
@@ -296,7 +296,7 @@ public:
     /**
      * Get the dimensions of the image viewer (window size).
      */
-    QSize getOutputSize( ) const;
+//    QSize getOutputSize( ) const;
 
     /**
      * Return percentiles corresponding to the given intensities.
@@ -569,7 +569,7 @@ public:
      *  are grouped and should be ungrouped.
      * @return - an error message if the group/ungroup message could not be performed.
      */
-    QString setSelectedLayersGrouped( bool grouped );
+//    QString setSelectedLayersGrouped( bool grouped );
 
     /**
      * Set whether or not selection of layers in the stack should be based on the
@@ -592,7 +592,7 @@ public:
      * @param imgX the x-coordinate for the center of the pan.
      * @param imgY the y-coordinate for the center of the pan.
      */
-    void updatePan( double imgX , double imgY);
+//    void updatePan( double imgX , double imgY);
 
     /**
      * Update the pan and zoom level settings.
@@ -601,7 +601,7 @@ public:
      * @param zoomLevel zoom level
      * @param layerId specify the id of a layerData to update its Pan and Zoom level
      */
-    void updatePanZoomLevelJS( double centerX, double centerY, double zoomLevel, double layerId );
+//    void updatePanZoomLevelJS( double centerX, double centerY, double zoomLevel, double layerId );
 
     /**
      * Update the pan and zoom settings.
@@ -609,7 +609,7 @@ public:
      * @param centerY the screen y-coordinate where the zoom was centered.
      * @param z either positive or negative depending on the desired zoom direction.
      */
-    void updatePanZoom( double centerX, double centerY, double zoomFactor);
+//    void updatePanZoom( double centerX, double centerY, double zoomFactor);
 
     void updateZoom(double zoomFactor);
 
@@ -688,7 +688,7 @@ private slots:
 	void _contourSetRemoved( const QString setName );
 
 	// void _gridChanged( const Carta::State::StateInterface& state, bool applyAll );
-	void _onInputEvent( InputEvent ev );
+//	void _onInputEvent( InputEvent ev );
 
 	//Refresh the view based on the latest data selection information.
 	void _loadView(  );
@@ -732,16 +732,16 @@ private:
 	//Return the rectangle (in pixel coordinates scaled to the display size)
 	//that is currently being viewed in the main view.  Used to show a rectangle
 	//in the context view.
-	QRectF _getInputRectangle() const;
+//	QRectF _getInputRectangle() const;
 	QString _getPreferencesId() const;
 	QString _getRegionControlsId() const;
 	QString _getStackId() const;
 
 	//Provide default values for state.
 	void _initializeState();
-	void _initializeCallbacks();
+//	void _initializeCallbacks();
 
-	void _renderZoom( double factor );
+//	void _renderZoom( double factor );
 	void _renderContext( double zoomFactor );
 
     // Set the AxisMapper::axisMap to use
@@ -753,7 +753,7 @@ private:
 	 * @param axisType - the axis for which a frame is being set.
 	 * @param frameIndex  a frame index for the axis.
 	 */
-	void _setFrameAxis(int frameIndex, Carta::Lib::AxisInfo::KnownType axisType );
+//	void _setFrameAxis(int frameIndex, Carta::Lib::AxisInfo::KnownType axisType );
 
 	QString _setLayersSelected( const QStringList indices);
 
@@ -761,8 +761,8 @@ private:
 	void _setViewDrawContext( std::shared_ptr<DrawStackSynchronizer> stackDraw );
     void _setViewDrawZoom( std::shared_ptr<DrawStackSynchronizer> drawZoom );
 
-	void _updateCursor( int mouseX, int mouseY );
-	void _updateCursorText(bool notifyClients );
+//	void _updateCursor( int mouseX, int mouseY );
+//	void _updateCursorText(bool notifyClients );
 	void _updateDisplayAxes( /*int targetIndex*/ );
 
 	static bool m_registered;

--- a/carta/cpp/core/Data/Image/Draw/DrawGroupSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawGroupSynchronizer.cpp
@@ -57,63 +57,63 @@ void DrawGroupSynchronizer::render(
     }
 }
 
-void DrawGroupSynchronizer::_scheduleFrameRepaint( const std::shared_ptr<RenderResponse>& response){
-    m_renderCount++;
-    m_images[response->getLayerName()] = response;
+//void DrawGroupSynchronizer::_scheduleFrameRepaint( const std::shared_ptr<RenderResponse>& response){
+//    m_renderCount++;
+//    m_images[response->getLayerName()] = response;
 
-    //If we are still waiting for other layers to finish, do nothing.
-    if ( m_renderCount != m_redrawCount ) {
-        return;
-    }
-    int dataCount = m_layers.size();
-    QImage image;
-    Carta::Lib::VectorGraphics::VGList graphics;
-    if ( m_imageSize.height() > 0 && m_imageSize.width() > 0 ){
-    	Carta::Lib::VectorGraphics::VGComposer comp = Carta::Lib::VectorGraphics::VGComposer( );
-        if ( m_combineMode == LayerCompositionModes::PLUS ){
-            std::shared_ptr<Carta::Lib::PixelMaskCombiner> pmc =
-                    std::make_shared < Carta::Lib::PixelMaskCombiner > ();
-            image = QImage(m_imageSize, QImage::Format_ARGB32 );
-            image.fill( QColor(0,0,0,0));
-            for ( int i = 0; i < dataCount; i++ ){
-                m_layers[i]->disconnect( this );
-                QString layerName = m_layers[i]->_getLayerId();
-                if ( m_images.contains( layerName ) ){
-                    std::shared_ptr<RenderResponse> response = m_images[layerName];
-                    QImage layerImage = response->getImage();
-                    Carta::Lib::VectorGraphics::VGList vgList = response->getVectorGraphics();
-                    if ( vgList.entries().size() > 0 ){
-                    	comp.appendList( vgList );
-                    }
-                    float alphaVal = m_layers[i]->_getMaskAlpha();
-                    pmc-> setAlpha( alphaVal );
-                    qint32 maskColor = m_layers[i]->_getMaskColor();
-                    pmc-> setMask( maskColor );
-                    pmc->combine( image, layerImage );
-                }
-            }
-            graphics = comp.vgList();
-        }
+//    //If we are still waiting for other layers to finish, do nothing.
+//    if ( m_renderCount != m_redrawCount ) {
+//        return;
+//    }
+//    int dataCount = m_layers.size();
+//    QImage image;
+//    Carta::Lib::VectorGraphics::VGList graphics;
+//    if ( m_imageSize.height() > 0 && m_imageSize.width() > 0 ){
+//    	Carta::Lib::VectorGraphics::VGComposer comp = Carta::Lib::VectorGraphics::VGComposer( );
+//        if ( m_combineMode == LayerCompositionModes::PLUS ){
+//            std::shared_ptr<Carta::Lib::PixelMaskCombiner> pmc =
+//                    std::make_shared < Carta::Lib::PixelMaskCombiner > ();
+//            image = QImage(m_imageSize, QImage::Format_ARGB32 );
+//            image.fill( QColor(0,0,0,0));
+//            for ( int i = 0; i < dataCount; i++ ){
+//                m_layers[i]->disconnect( this );
+//                QString layerName = m_layers[i]->_getLayerId();
+//                if ( m_images.contains( layerName ) ){
+//                    std::shared_ptr<RenderResponse> response = m_images[layerName];
+//                    QImage layerImage = response->getImage();
+//                    Carta::Lib::VectorGraphics::VGList vgList = response->getVectorGraphics();
+//                    if ( vgList.entries().size() > 0 ){
+//                    	comp.appendList( vgList );
+//                    }
+//                    float alphaVal = m_layers[i]->_getMaskAlpha();
+//                    pmc-> setAlpha( alphaVal );
+//                    qint32 maskColor = m_layers[i]->_getMaskColor();
+//                    pmc-> setMask( maskColor );
+//                    pmc->combine( image, layerImage );
+//                }
+//            }
+//            graphics = comp.vgList();
+//        }
 
-        else {
-            if ( dataCount > 0 ){
-                //Implement for now to just get one image.
-                QString imageName = m_layers[0]->_getLayerId();
-                if ( m_images.contains( imageName ) ){
-                	graphics = m_images[imageName]->getVectorGraphics();
-                    image = m_images[imageName]->getImage();
-                }
-            }
-        }
+//        else {
+//            if ( dataCount > 0 ){
+//                //Implement for now to just get one image.
+//                QString imageName = m_layers[0]->_getLayerId();
+//                if ( m_images.contains( imageName ) ){
+//                	graphics = m_images[imageName]->getVectorGraphics();
+//                    image = m_images[imageName]->getImage();
+//                }
+//            }
+//        }
 
 
-    }
-    for ( int i = 0; i < dataCount; i++ ){
-        m_layers[i]->_renderDone();
-    }
-    m_repaintFrameQueued = false;
-    emit done( image, graphics );
-}
+//    }
+//    for ( int i = 0; i < dataCount; i++ ){
+//        m_layers[i]->_renderDone();
+//    }
+//    m_repaintFrameQueued = false;
+//    emit done( image, graphics );
+//}
 
 void DrawGroupSynchronizer::setCombineMode( const QString& mode ){
     m_combineMode = mode;

--- a/carta/cpp/core/Data/Image/Draw/DrawGroupSynchronizer.h
+++ b/carta/cpp/core/Data/Image/Draw/DrawGroupSynchronizer.h
@@ -75,7 +75,7 @@ private slots:
     /**
     * Notification that a stack layer has finished rendering its image.
     */
-    void _scheduleFrameRepaint( const std::shared_ptr<RenderResponse>& );
+//    void _scheduleFrameRepaint( const std::shared_ptr<RenderResponse>& );
 
 private:
 

--- a/carta/cpp/core/Data/Image/Draw/DrawImageViewsSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawImageViewsSynchronizer.cpp
@@ -18,17 +18,17 @@ DrawImageViewsSynchronizer::DrawImageViewsSynchronizer( QObject* parent)
 
 void DrawImageViewsSynchronizer::_doneMain( bool /*drawn*/){
     m_busy = false;
-    _startNextDraw();
+//    _startNextDraw();
 }
 
 void DrawImageViewsSynchronizer::_doneContext( bool /*drawn*/ ){
     m_busy = false;
-    _startNextDraw();
+//    _startNextDraw();
 }
 
 void DrawImageViewsSynchronizer::_doneZoom( bool /*drawn*/){
     m_busy = false;
-    _startNextDraw();
+//    _startNextDraw();
 }
 
 bool DrawImageViewsSynchronizer::isContextView() const {
@@ -68,7 +68,7 @@ void DrawImageViewsSynchronizer::render( const std::shared_ptr<RenderRequest>& r
 		}
 
 		//Store the data & request.
-		_startNextDraw();
+//		_startNextDraw();
 	}
 }
 
@@ -93,25 +93,25 @@ void DrawImageViewsSynchronizer::setViewDrawZoom( std::shared_ptr<DrawStackSynch
     }
 }
 
-void DrawImageViewsSynchronizer::_startNextDraw(){
-    if ( m_requests.size() > 0 ){
-        m_busy = true;
-        std::shared_ptr<RenderRequest> request = m_requests.dequeue();
-        if ( request->isRequestMain() ){
-            //Start the main renderer
-            request->setOutputSize( m_drawMain->getClientSize() );
-            m_drawMain-> _render( request);
-        }
-        else if ( request->isRequestContext() ){
-            request->setOutputSize( m_drawContext->getClientSize() );
-            m_drawContext-> _render(request);
-        }
-        else if ( request->isRequestZoom() ){
-            request->setOutputSize( m_drawZoom->getClientSize() );
-            m_drawZoom->_render(request);
-        }
-    }
-}
+//void DrawImageViewsSynchronizer::_startNextDraw(){
+//    if ( m_requests.size() > 0 ){
+//        m_busy = true;
+//        std::shared_ptr<RenderRequest> request = m_requests.dequeue();
+//        if ( request->isRequestMain() ){
+//            //Start the main renderer
+//            request->setOutputSize( m_drawMain->getClientSize() );
+//            m_drawMain-> _render( request);
+//        }
+//        else if ( request->isRequestContext() ){
+//            request->setOutputSize( m_drawContext->getClientSize() );
+//            m_drawContext-> _render(request);
+//        }
+//        else if ( request->isRequestZoom() ){
+//            request->setOutputSize( m_drawZoom->getClientSize() );
+//            m_drawZoom->_render(request);
+//        }
+//    }
+//}
 
 
 DrawImageViewsSynchronizer::~DrawImageViewsSynchronizer(){

--- a/carta/cpp/core/Data/Image/Draw/DrawImageViewsSynchronizer.h
+++ b/carta/cpp/core/Data/Image/Draw/DrawImageViewsSynchronizer.h
@@ -95,7 +95,7 @@ private:
     /**
      * Start the next rendered view of the image.
      */
-    void _startNextDraw();
+//    void _startNextDraw();
 
     bool m_busy;
 

--- a/carta/cpp/core/Data/Image/Draw/DrawStackSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawStackSynchronizer.cpp
@@ -27,9 +27,9 @@ void DrawStackSynchronizer::_clear(){
     QMetaObject::invokeMethod( this, "_repaintFrameNow", Qt::QueuedConnection );
 }
 
-QSize DrawStackSynchronizer::getClientSize() const {
-    return m_view->getClientSize();
-}
+//QSize DrawStackSynchronizer::getClientSize() const {
+//    return m_view->getClientSize();
+//}
 
 
 QList<std::shared_ptr<Layer> > DrawStackSynchronizer::_getLoadableData( const std::shared_ptr<RenderRequest>& request ){
@@ -50,107 +50,107 @@ void DrawStackSynchronizer::_repaintFrameNow(){
 
 }
 
-void DrawStackSynchronizer::_render( const std::shared_ptr<RenderRequest>& request ){
-    if ( m_repaintFrameQueued ){
-        emit done( false );
-        return;
-    }
-    QSize clientSize = getClientSize();
-    if ( clientSize.width() <= 1 || clientSize.height() <= 1 ){
-        emit done( false );
-        return;
-    }
+//void DrawStackSynchronizer::_render( const std::shared_ptr<RenderRequest>& request ){
+//    if ( m_repaintFrameQueued ){
+//        emit done( false );
+//        return;
+//    }
+//    QSize clientSize = getClientSize();
+//    if ( clientSize.width() <= 1 || clientSize.height() <= 1 ){
+//        emit done( false );
+//        return;
+//    }
 
-    m_repaintFrameQueued = true;
-    QList<std::shared_ptr<Layer> > datas = _getLoadableData( request );
-    int dataCount = datas.size();
-    m_images.clear();
-    m_layers = datas;
-    int topIndex = request->getTopIndex();
-    m_selectIndex = topIndex;
-    m_renderCount = 0;
-    m_redrawCount = dataCount;
+//    m_repaintFrameQueued = true;
+//    QList<std::shared_ptr<Layer> > datas = _getLoadableData( request );
+//    int dataCount = datas.size();
+//    m_images.clear();
+//    m_layers = datas;
+//    int topIndex = request->getTopIndex();
+//    m_selectIndex = topIndex;
+//    m_renderCount = 0;
+//    m_redrawCount = dataCount;
 
-    for ( int i = 0; i < dataCount; i++ ){
-        if ( datas[i]->_isVisible() ){
-            connect( datas[i].get(), SIGNAL(renderingDone(const std::shared_ptr<RenderResponse>&)),
-                    this, SLOT(_scheduleFrameRepaint(const std::shared_ptr<RenderResponse>&)),
-                    Qt::UniqueConnection);
-            bool topOfStack = false;
-            if ( i == topIndex ){
-                topOfStack = true;
-            }
-            std::shared_ptr<RenderRequest> layerRequest( new RenderRequest(
-                                   *request ));
-            layerRequest->setStackTop( topOfStack );
-            datas[i]->_render( layerRequest );
-        }
-    }
-    if ( dataCount == 0 ){
+//    for ( int i = 0; i < dataCount; i++ ){
+//        if ( datas[i]->_isVisible() ){
+//            connect( datas[i].get(), SIGNAL(renderingDone(const std::shared_ptr<RenderResponse>&)),
+//                    this, SLOT(_scheduleFrameRepaint(const std::shared_ptr<RenderResponse>&)),
+//                    Qt::UniqueConnection);
+//            bool topOfStack = false;
+//            if ( i == topIndex ){
+//                topOfStack = true;
+//            }
+//            std::shared_ptr<RenderRequest> layerRequest( new RenderRequest(
+//                                   *request ));
+//            layerRequest->setStackTop( topOfStack );
+//            datas[i]->_render( layerRequest );
+//        }
+//    }
+//    if ( dataCount == 0 ){
 
-        m_repaintFrameQueued = false;
-        _clear();
-        emit done( true );
-    }
-}
-
-
-void DrawStackSynchronizer::_scheduleFrameRepaint( const std::shared_ptr<RenderResponse>& response ){
-
-    if ( !m_repaintFrameQueued ){
-        return;
-    }
-    // if reload is already pending, do nothing
-    m_renderCount++;
-    m_images[response->getLayerName()] = response;
-    if ( m_renderCount != m_redrawCount ) {
-        return;
-    }
-    m_view->removeAllLayers();
-
-    //We want the selected index to be the last one in the stack.
-    int dataCount = m_layers.size();
-    int stackIndex = 0;
-    for ( int i = 0; i < dataCount; i++ ){
-        int dIndex = ( m_selectIndex + i + 1) % dataCount;
-        m_layers[dIndex]->disconnect( this );
-        bool layerEmpty = m_layers[dIndex]->_isEmpty();
-        bool layerVisible = m_layers[dIndex]->_isVisible();
-        if ( layerVisible && !layerEmpty){
-            QString layerName = m_layers[dIndex]->_getLayerId();
-            if ( m_images.contains( layerName ) ){
-                QImage image = m_images[layerName]->getImage();
-                Carta::Lib::VectorGraphics::VGList graphicsList = m_images[layerName]->getVectorGraphics();
-                m_view->setLayerRaster( stackIndex, image, false );
-                std::shared_ptr<Carta::Lib::AlphaCombiner> alphaCombine =
-                        std::make_shared<Carta::Lib::AlphaCombiner>();
-                float alphaVal = m_layers[dIndex]->_getMaskAlpha();
-                alphaCombine-> setAlpha( alphaVal );
-                m_view->setLayerCombiner( stackIndex, alphaCombine );
-                stackIndex++;
-                m_view->setLayerVG( stackIndex, graphicsList );
-                stackIndex++;
-            }
-        }
-    }
+//        m_repaintFrameQueued = false;
+//        _clear();
+//        emit done( true );
+//    }
+//}
 
 
-    m_repaintFrameQueued = false;
+//void DrawStackSynchronizer::_scheduleFrameRepaint( const std::shared_ptr<RenderResponse>& response ){
 
-    // create a copy, since "emit done" will invoke "DrawStackSynchronizer::_render"
-    // which will call "m_layers = datas;"
-    QList< std::shared_ptr<Layer> > m_layers_copy = m_layers;
+//    if ( !m_repaintFrameQueued ){
+//        return;
+//    }
+//    // if reload is already pending, do nothing
+//    m_renderCount++;
+//    m_images[response->getLayerName()] = response;
+//    if ( m_renderCount != m_redrawCount ) {
+//        return;
+//    }
+//    m_view->removeAllLayers();
 
-    emit done( true );
+//    //We want the selected index to be the last one in the stack.
+//    int dataCount = m_layers.size();
+//    int stackIndex = 0;
+//    for ( int i = 0; i < dataCount; i++ ){
+//        int dIndex = ( m_selectIndex + i + 1) % dataCount;
+//        m_layers[dIndex]->disconnect( this );
+//        bool layerEmpty = m_layers[dIndex]->_isEmpty();
+//        bool layerVisible = m_layers[dIndex]->_isVisible();
+//        if ( layerVisible && !layerEmpty){
+//            QString layerName = m_layers[dIndex]->_getLayerId();
+//            if ( m_images.contains( layerName ) ){
+//                QImage image = m_images[layerName]->getImage();
+//                Carta::Lib::VectorGraphics::VGList graphicsList = m_images[layerName]->getVectorGraphics();
+//                m_view->setLayerRaster( stackIndex, image, false );
+//                std::shared_ptr<Carta::Lib::AlphaCombiner> alphaCombine =
+//                        std::make_shared<Carta::Lib::AlphaCombiner>();
+//                float alphaVal = m_layers[dIndex]->_getMaskAlpha();
+//                alphaCombine-> setAlpha( alphaVal );
+//                m_view->setLayerCombiner( stackIndex, alphaCombine );
+//                stackIndex++;
+//                m_view->setLayerVG( stackIndex, graphicsList );
+//                stackIndex++;
+//            }
+//        }
+//    }
 
-    // QMetaObject::invokeMethod( this, "_repaintFrameNow", Qt::QueuedConnection );
-    for ( int i = 0; i < dataCount; i++ ){
-        m_layers_copy[i]->_renderDone();
-    }
 
-    m_view->scheduleRepaint();
+//    m_repaintFrameQueued = false;
 
-}
+//    // create a copy, since "emit done" will invoke "DrawStackSynchronizer::_render"
+//    // which will call "m_layers = datas;"
+//    QList< std::shared_ptr<Layer> > m_layers_copy = m_layers;
+
+//    emit done( true );
+
+//    // QMetaObject::invokeMethod( this, "_repaintFrameNow", Qt::QueuedConnection );
+//    for ( int i = 0; i < dataCount; i++ ){
+//        m_layers_copy[i]->_renderDone();
+//    }
+
+//    m_view->scheduleRepaint();
+
+//}
 
 
 

--- a/carta/cpp/core/Data/Image/Draw/DrawStackSynchronizer.h
+++ b/carta/cpp/core/Data/Image/Draw/DrawStackSynchronizer.h
@@ -48,7 +48,7 @@ public:
      * Return the client view size.
      * @return - the size of the stack view on the client.
      */
-    QSize getClientSize() const;
+//    QSize getClientSize() const;
 
     virtual ~DrawStackSynchronizer();
 
@@ -82,7 +82,7 @@ private slots:
     /**
     * Notification that a stack layer has changed its image or vector graphics.
     */
-    void _scheduleFrameRepaint( const std::shared_ptr<RenderResponse>& response );
+//    void _scheduleFrameRepaint( const std::shared_ptr<RenderResponse>& response );
 
 private:
 
@@ -91,7 +91,7 @@ private:
     //Return the list of data that can actually load the indicated frames.
     QList<std::shared_ptr<Layer> >  _getLoadableData( const std::shared_ptr<RenderRequest>& request );
 
-    void _render( const std::shared_ptr<RenderRequest>& request );
+//    void _render( const std::shared_ptr<RenderRequest>& request );
 
     //Data View
     std::unique_ptr<Carta::Lib::LayeredViewArbitrary> m_view;

--- a/carta/cpp/core/Data/Image/ImageContext.cpp
+++ b/carta/cpp/core/Data/Image/ImageContext.cpp
@@ -84,7 +84,7 @@ QString ImageContext::addLink( CartaObject* cartaObject ){
             connect( m_contextDraw.get(), SIGNAL(viewResize()), this, SLOT(_contextChanged()));
             //connect( controller, SIGNAL(dataChanged(Controller*)), this, SLOT(_contextChanged()));
             connect( controller, SIGNAL(contextChanged()), this, SLOT(_contextChanged()));
-            _contextChanged();
+//            _contextChanged();
         }
     }
     else {
@@ -106,122 +106,122 @@ void ImageContext::_clearView(){
     m_contextDraw->_clear();
 }
 
-void ImageContext::_contextChanged(){
-	if ( !m_mouseDown ){
-		int linkCount = m_linkImpl->getLinkCount();
-		if ( linkCount > 0 ){
-			Controller* alt = dynamic_cast<Controller*>( m_linkImpl->getLink(0) );
-			if ( alt != nullptr ){
-				//Get the size of the image.
-				QSize imageSize = alt->_getDisplaySize();
-				double outputHeight = imageSize.height();
-				double outputWidth = imageSize.width();
-				if ( outputHeight > 1 && outputWidth > 1 ){
+//void ImageContext::_contextChanged(){
+//	if ( !m_mouseDown ){
+//		int linkCount = m_linkImpl->getLinkCount();
+//		if ( linkCount > 0 ){
+//			Controller* alt = dynamic_cast<Controller*>( m_linkImpl->getLink(0) );
+//			if ( alt != nullptr ){
+//				//Get the size of the image.
+//				QSize imageSize = alt->_getDisplaySize();
+//				double outputHeight = imageSize.height();
+//				double outputWidth = imageSize.width();
+//				if ( outputHeight > 1 && outputWidth > 1 ){
 
-					//Size of the context window.
-					QSize contextSize = m_contextDraw->getClientSize();
-					double contextWidth = contextSize.width();
-					double contextHeight = contextSize.height();
+//					//Size of the context window.
+//					QSize contextSize = m_contextDraw->getClientSize();
+//					double contextWidth = contextSize.width();
+//					double contextHeight = contextSize.height();
 
-					//Actual output size should be the minimum of the image and the
-					//context rectangle - we don't want an image larger that the view
-					//that can hold it.  However, we do want to preserve the image dimensions.
-					double actualHeight = outputHeight;
-					double actualWidth = outputWidth;
-					double zoomFactor = 1;
-					//Determine whether width or height is the most constrained factor.
-					double widthRatio = contextWidth / outputWidth;
-					double heightRatio = contextHeight / outputHeight;
-					//Height is the more constrained resource.
-					if ( heightRatio < widthRatio ){
-						//Choose height to be the smallest of image and window height.
-						actualHeight = qMin( contextHeight, outputHeight );
-						//Determine how much it has been constrained
-						zoomFactor = actualHeight / outputHeight;
-						//Use the ratio to get width
-						actualWidth = outputWidth * zoomFactor;
-					}
-					else {
-						actualWidth = qMin( contextWidth, outputWidth );
-						zoomFactor = actualWidth / outputWidth;
-						actualHeight = outputHeight * zoomFactor;
-					}
+//					//Actual output size should be the minimum of the image and the
+//					//context rectangle - we don't want an image larger that the view
+//					//that can hold it.  However, we do want to preserve the image dimensions.
+//					double actualHeight = outputHeight;
+//					double actualWidth = outputWidth;
+//					double zoomFactor = 1;
+//					//Determine whether width or height is the most constrained factor.
+//					double widthRatio = contextWidth / outputWidth;
+//					double heightRatio = contextHeight / outputHeight;
+//					//Height is the more constrained resource.
+//					if ( heightRatio < widthRatio ){
+//						//Choose height to be the smallest of image and window height.
+//						actualHeight = qMin( contextHeight, outputHeight );
+//						//Determine how much it has been constrained
+//						zoomFactor = actualHeight / outputHeight;
+//						//Use the ratio to get width
+//						actualWidth = outputWidth * zoomFactor;
+//					}
+//					else {
+//						actualWidth = qMin( contextWidth, outputWidth );
+//						zoomFactor = actualWidth / outputWidth;
+//						actualHeight = outputHeight * zoomFactor;
+//					}
 
-					if ( zoomFactor > 0 ){
-						bool contextChanged = false;
-						int oldWidth = m_stateData.getValue<int>( IMAGE_WIDTH );
-						int oldHeight = m_stateData.getValue<int>( IMAGE_HEIGHT );
-						if ( oldWidth != actualWidth || oldHeight != actualHeight ){
-							m_stateData.setValue<int>( IMAGE_WIDTH, actualWidth );
-							m_stateData.setValue<int>( IMAGE_HEIGHT, actualHeight );
-							contextChanged = true;
-						}
+//					if ( zoomFactor > 0 ){
+//						bool contextChanged = false;
+//						int oldWidth = m_stateData.getValue<int>( IMAGE_WIDTH );
+//						int oldHeight = m_stateData.getValue<int>( IMAGE_HEIGHT );
+//						if ( oldWidth != actualWidth || oldHeight != actualHeight ){
+//							m_stateData.setValue<int>( IMAGE_WIDTH, actualWidth );
+//							m_stateData.setValue<int>( IMAGE_HEIGHT, actualHeight );
+//							contextChanged = true;
+//						}
 
-						//Get the rectangle inside the image that is visible in the
-						//main view.
-						QRectF inputRect = alt->_getInputRectangle();
-						QPointF topLeft = inputRect.topLeft();
-						QPointF bottomRight = inputRect.bottomRight();
+//						//Get the rectangle inside the image that is visible in the
+//						//main view.
+//						QRectF inputRect = alt->_getInputRectangle();
+//						QPointF topLeft = inputRect.topLeft();
+//						QPointF bottomRight = inputRect.bottomRight();
 
-						//Scale the input rectangle to the context zoom.
-						QPointF topLeftZoomed (topLeft.x() * zoomFactor, topLeft.y() * zoomFactor );
-						QPointF bottomRightZoomed( bottomRight.x() * zoomFactor,bottomRight.y() * zoomFactor );
+//						//Scale the input rectangle to the context zoom.
+//						QPointF topLeftZoomed (topLeft.x() * zoomFactor, topLeft.y() * zoomFactor );
+//						QPointF bottomRightZoomed( bottomRight.x() * zoomFactor,bottomRight.y() * zoomFactor );
 
-						//Account for margins between the view window and the actual image.
-						double translateX = (contextWidth - actualWidth) / 2;
-						double translateY = (contextHeight - actualHeight) / 2;
-						double topY = topLeftZoomed.y() + translateY;
-						double leftX = topLeftZoomed.x() + translateX;
-						QPointF topLeftTranslate( leftX, topY );
-						double bottomY = bottomRightZoomed.y() + translateY;
-						double rightX = bottomRightZoomed.x() + translateX;
-						QPointF bottomRightTranslate( rightX, bottomY );
+//						//Account for margins between the view window and the actual image.
+//						double translateX = (contextWidth - actualWidth) / 2;
+//						double translateY = (contextHeight - actualHeight) / 2;
+//						double topY = topLeftZoomed.y() + translateY;
+//						double leftX = topLeftZoomed.x() + translateX;
+//						QPointF topLeftTranslate( leftX, topY );
+//						double bottomY = bottomRightZoomed.y() + translateY;
+//						double rightX = bottomRightZoomed.x() + translateX;
+//						QPointF bottomRightTranslate( rightX, bottomY );
 
-						//Store the location of the image rectangle.
-						QRectF oldRect = getImageRectangle();
-						if ( oldRect.bottomRight() != bottomRightTranslate || oldRect.topLeft() != topLeftTranslate ){
-							setImageRectangle(  bottomRightTranslate, topLeftTranslate );
-							contextChanged = true;
-						}
+//						//Store the location of the image rectangle.
+//						QRectF oldRect = getImageRectangle();
+//						if ( oldRect.bottomRight() != bottomRightTranslate || oldRect.topLeft() != topLeftTranslate ){
+//							setImageRectangle(  bottomRightTranslate, topLeftTranslate );
+//							contextChanged = true;
+//						}
 
-						//Get the native value at the center
-						bool validCenter = false;
-						QPointF imageCenterWorld = alt->getWorldCoordinates( outputWidth/2, outputHeight/2, &validCenter );
+//						//Get the native value at the center
+//						bool validCenter = false;
+//						QPointF imageCenterWorld = alt->getWorldCoordinates( outputWidth/2, outputHeight/2, &validCenter );
 
-						//Get the native value to the left of center.
-						bool validLeft = false;
-						QPointF imageLeftWorld = alt->getWorldCoordinates( 0, outputHeight/2, &validLeft );
-						if ( validLeft && validCenter ){
-							//Calculate the angle.
-							double ratio = ( imageCenterWorld.y() - imageLeftWorld.y() ) /
-									( imageCenterWorld.x() - imageLeftWorld.x() );
-							double angle = atan ( ratio );
-							double oldAngle = m_stateData.getValue<double>(COORD_ROTATION);
-							if ( angle != oldAngle ){
-								m_stateData.setValue<double>( COORD_ROTATION, angle );
-								contextChanged = true;
-							}
-						}
-						if ( contextChanged ){
-							m_stateData.flushState();
-							//Redraw it.
-							alt->_renderContext( zoomFactor );
-						}
-					}
-				}
-				else {
-					_clearDraw();
-					_clearView();
-				}
-			}
-		}
-		//No controllers so just clear the view.
-		else {
-			_clearDraw();
-			_clearView();
-		}
-	}
-}
+//						//Get the native value to the left of center.
+//						bool validLeft = false;
+//						QPointF imageLeftWorld = alt->getWorldCoordinates( 0, outputHeight/2, &validLeft );
+//						if ( validLeft && validCenter ){
+//							//Calculate the angle.
+//							double ratio = ( imageCenterWorld.y() - imageLeftWorld.y() ) /
+//									( imageCenterWorld.x() - imageLeftWorld.x() );
+//							double angle = atan ( ratio );
+//							double oldAngle = m_stateData.getValue<double>(COORD_ROTATION);
+//							if ( angle != oldAngle ){
+//								m_stateData.setValue<double>( COORD_ROTATION, angle );
+//								contextChanged = true;
+//							}
+//						}
+//						if ( contextChanged ){
+//							m_stateData.flushState();
+//							//Redraw it.
+//							alt->_renderContext( zoomFactor );
+//						}
+//					}
+//				}
+//				else {
+//					_clearDraw();
+//					_clearView();
+//				}
+//			}
+//		}
+//		//No controllers so just clear the view.
+//		else {
+//			_clearDraw();
+//			_clearView();
+//		}
+//	}
+//}
 
 
 Controller* ImageContext::_getControllerSelected() const {
@@ -543,7 +543,7 @@ void ImageContext::_updateSelection( int mouseX, int mouseY ){
         QPointF newTopLeft( topLeft.x() + moveX, topLeft.y() + moveY );
         QPointF newBottomRight( bottomRight.x() + moveX, bottomRight.y() + moveY );
         setImageRectangle(newBottomRight, newTopLeft );
-        _updateImageView( newTopLeft, newBottomRight );
+//        _updateImageView( newTopLeft, newBottomRight );
     }
 }
 
@@ -569,7 +569,7 @@ QString ImageContext::removeLink( CartaObject* cartaObject ){
             controller->_setViewDrawContext( std::shared_ptr<DrawStackSynchronizer>( nullptr) );
 
             _clearDraw();
-            _contextChanged();
+//            _contextChanged();
         }
     }
     else {
@@ -717,22 +717,22 @@ void ImageContext::setImageRectangle( QPointF br, QPointF tl ){
 	}
 }
 
-void ImageContext::_updateImageView( const QPointF& topLeft, const QPointF& bottomRight ){
-	//Change pixels to image coordinates.
-	Controller* controller = _getControllerSelected();
-	if ( controller ){
-		QSize clientSize = m_contextDraw->getClientSize();
-		bool tlValid = false;
-		QPointF imageTL = controller->_getContextPt( topLeft, clientSize, &tlValid );
-		bool brValid = false;
-		QPointF imageBR = controller->_getContextPt( bottomRight, clientSize, &brValid );
-		if ( tlValid && brValid ){
-			double centerX = ( imageTL.x() + imageBR.x() ) / 2;
-			double centerY = ( imageTL.y() + imageBR.y() ) / 2;
-			controller->centerOnPixel( centerX, centerY);
-		}
-	}
-}
+//void ImageContext::_updateImageView( const QPointF& topLeft, const QPointF& bottomRight ){
+//	//Change pixels to image coordinates.
+//	Controller* controller = _getControllerSelected();
+//	if ( controller ){
+//		QSize clientSize = m_contextDraw->getClientSize();
+//		bool tlValid = false;
+//		QPointF imageTL = controller->_getContextPt( topLeft, clientSize, &tlValid );
+//		bool brValid = false;
+//		QPointF imageBR = controller->_getContextPt( bottomRight, clientSize, &brValid );
+//		if ( tlValid && brValid ){
+//			double centerX = ( imageTL.x() + imageBR.x() ) / 2;
+//			double centerY = ( imageTL.y() + imageBR.y() ) / 2;
+//			controller->centerOnPixel( centerX, centerY);
+//		}
+//	}
+//}
 
 QString ImageContext::setTabIndex( int index ){
     QString result;

--- a/carta/cpp/core/Data/Image/ImageContext.h
+++ b/carta/cpp/core/Data/Image/ImageContext.h
@@ -168,7 +168,7 @@ private slots:
     /**
      * Redraw the context image.
      */
-    void _contextChanged();
+//    void _contextChanged();
 
 private:
 
@@ -199,7 +199,7 @@ private:
             const QString& key, const QString& userID );
     QString _setLineWidth( const QString& key, const QString& userName, int width );
     void _setVisible( bool visible, const QString& key);
-    void _updateImageView( const QPointF& topLeft, const QPointF& bottomRight );
+//    void _updateImageView( const QPointF& topLeft, const QPointF& bottomRight );
     void _updateSelection( int mouseX, int mouseY );
 
     //Link management

--- a/carta/cpp/core/Data/Image/ImageZoom.cpp
+++ b/carta/cpp/core/Data/Image/ImageZoom.cpp
@@ -307,7 +307,7 @@ QString ImageZoom::removeLink( CartaObject* cartaObject ){
         if ( linkRemoved  ){
             controller->disconnect( this );
             controller->_setViewDrawZoom( std::shared_ptr<DrawStackSynchronizer>( nullptr) );
-            _zoomChanged();
+//            _zoomChanged();
         }
     }
     else {
@@ -419,58 +419,58 @@ QString ImageZoom::setZoomFactor( int zoomFactor ){
         if ( oldFactor != zoomFactor ){
             m_state.setValue<int>( ZOOM_FACTOR, zoomFactor );
             m_state.flushState();
-            _zoomChanged();
+//            _zoomChanged();
         }
     }
     return result;
 }
 
 
-void ImageZoom::_zoomChanged(){
-    int linkCount = m_linkImpl->getLinkCount();
-    if ( linkCount > 0 ){
-        Controller* alt = dynamic_cast<Controller*>( m_linkImpl->getLink(0) );
-        if ( alt != nullptr ){
-            bool valid = false;
-            QPointF imgPt = alt->getImagePt( &valid );
-            if ( valid ){
-                QSize displaySize = alt->_getDisplaySize();
+//void ImageZoom::_zoomChanged(){
+//    int linkCount = m_linkImpl->getLinkCount();
+//    if ( linkCount > 0 ){
+//        Controller* alt = dynamic_cast<Controller*>( m_linkImpl->getLink(0) );
+//        if ( alt != nullptr ){
+//            bool valid = false;
+//            QPointF imgPt = alt->getImagePt( &valid );
+//            if ( valid ){
+//                QSize displaySize = alt->_getDisplaySize();
 
-                //Do a zoom if the image pt is inside the image
-                if ( 0 <= imgPt.x() && imgPt.x()< displaySize.width() &&
-                        0 <= imgPt.y() && imgPt.y()<displaySize.height() ){
-                    double zoomFactor = alt->getZoomLevel();
-                    zoomFactor = zoomFactor * getZoomFactor();
-                    QSize outputSize = m_zoomDraw->getClientSize();
-                    double centerX = outputSize.width() / 2;
-                    double centerY = outputSize.height() / 2;
-                    QPointF topLeft( centerX - zoomFactor / 2, centerY - zoomFactor / 2);
-                    QPointF bottomRight( centerX + zoomFactor / 2, centerY + zoomFactor / 2 );
+//                //Do a zoom if the image pt is inside the image
+//                if ( 0 <= imgPt.x() && imgPt.x()< displaySize.width() &&
+//                        0 <= imgPt.y() && imgPt.y()<displaySize.height() ){
+//                    double zoomFactor = alt->getZoomLevel();
+//                    zoomFactor = zoomFactor * getZoomFactor();
+//                    QSize outputSize = m_zoomDraw->getClientSize();
+//                    double centerX = outputSize.width() / 2;
+//                    double centerY = outputSize.height() / 2;
+//                    QPointF topLeft( centerX - zoomFactor / 2, centerY - zoomFactor / 2);
+//                    QPointF bottomRight( centerX + zoomFactor / 2, centerY + zoomFactor / 2 );
 
-                    //Store the location of the image rectangle.
-                    setPixelRectangle(  topLeft, bottomRight );
+//                    //Store the location of the image rectangle.
+//                    setPixelRectangle(  topLeft, bottomRight );
 
-                    //Redraw it.
-                    alt->_renderZoom( zoomFactor );
-                }
-                //Cursor is off the image so clear.
-                else {
-                    _clearDraw();
-                    _clearView();
-                }
-            }
-            else {
-                _clearDraw();
-                _clearView();
-            }
-        }
-    }
-    //Clear, no linked controller.
-    else {
-        _clearDraw();
-        _clearView();
-    }
-}
+//                    //Redraw it.
+//                    alt->_renderZoom( zoomFactor );
+//                }
+//                //Cursor is off the image so clear.
+//                else {
+//                    _clearDraw();
+//                    _clearView();
+//                }
+//            }
+//            else {
+//                _clearDraw();
+//                _clearView();
+//            }
+//        }
+//    }
+//    //Clear, no linked controller.
+//    else {
+//        _clearDraw();
+//        _clearView();
+//    }
+//}
 
 
 ImageZoom::~ImageZoom(){

--- a/carta/cpp/core/Data/Image/ImageZoom.h
+++ b/carta/cpp/core/Data/Image/ImageZoom.h
@@ -118,7 +118,7 @@ public:
 
 private slots:
 
-    void _zoomChanged();
+//    void _zoomChanged();
 
 private:
 

--- a/carta/cpp/core/Data/Image/Save/SaveService.cpp
+++ b/carta/cpp/core/Data/Image/Save/SaveService.cpp
@@ -78,39 +78,39 @@ void SaveService::_saveImage( QImage img ){
     emit saveImageResult( result );
 }
 
-void SaveService::_scheduleSave( const std::shared_ptr<RenderResponse>& response ){
-    m_renderCount++;
-    m_images[response->getLayerName()] = response;
-    if ( m_renderCount != m_redrawCount ) {
-        return;
-    }
+//void SaveService::_scheduleSave( const std::shared_ptr<RenderResponse>& response ){
+//    m_renderCount++;
+//    m_images[response->getLayerName()] = response;
+//    if ( m_renderCount != m_redrawCount ) {
+//        return;
+//    }
 
-    m_view->resetLayers();
+//    m_view->resetLayers();
 
-    //We want the selected index to be the last one in the stack.
-    int dataCount = m_layers.size();
-    int stackIndex = 0;
-    for ( int i = 0; i < dataCount; i++ ){
-        int dIndex = ( m_selectIndex + i + 1) % dataCount;
-        m_layers[dIndex]->disconnect( this );
-        if ( m_layers[dIndex]->_isVisible() ){
-            QString layerId = m_layers[dIndex]->_getLayerId();
-            if ( m_images.contains( layerId ) ){
-                QImage image = m_images[layerId]->getImage();
-                Carta::Lib::VectorGraphics::VGList graphicsList = m_images[layerId]->getVectorGraphics();
-                m_view->setRasterLayer( stackIndex, image );
-                m_view->setVectorGraphicsLayer( stackIndex, graphicsList );
-                stackIndex++;
-            }
-        }
-    }
-    for ( int i = 0; i < dataCount; i++ ){
-           m_layers[i]->_renderDone();
-       }
-    m_view->paintLayers();
-    QImage image = m_view->getImage();
-    _saveImage( image );
-}
+//    //We want the selected index to be the last one in the stack.
+//    int dataCount = m_layers.size();
+//    int stackIndex = 0;
+//    for ( int i = 0; i < dataCount; i++ ){
+//        int dIndex = ( m_selectIndex + i + 1) % dataCount;
+//        m_layers[dIndex]->disconnect( this );
+//        if ( m_layers[dIndex]->_isVisible() ){
+//            QString layerId = m_layers[dIndex]->_getLayerId();
+//            if ( m_images.contains( layerId ) ){
+//                QImage image = m_images[layerId]->getImage();
+//                Carta::Lib::VectorGraphics::VGList graphicsList = m_images[layerId]->getVectorGraphics();
+//                m_view->setRasterLayer( stackIndex, image );
+//                m_view->setVectorGraphicsLayer( stackIndex, graphicsList );
+//                stackIndex++;
+//            }
+//        }
+//    }
+//    for ( int i = 0; i < dataCount; i++ ){
+//           m_layers[i]->_renderDone();
+//       }
+//    m_view->paintLayers();
+//    QImage image = m_view->getImage();
+//    _saveImage( image );
+//}
 
 void SaveService::setFileName( const QString& saveName ){
    m_fileName = saveName;

--- a/carta/cpp/core/Data/Image/Save/SaveService.h
+++ b/carta/cpp/core/Data/Image/Save/SaveService.h
@@ -73,9 +73,9 @@ signals:
 
 private slots:
 
-    void _scheduleSave(/*const QImage& qImage,
-            const Carta::Lib::VectorGraphics::VGList& vg, const QString& layerName*/
-            const std::shared_ptr<RenderResponse>& response);
+//    void _scheduleSave(/*const QImage& qImage,
+//            const Carta::Lib::VectorGraphics::VGList& vg, const QString& layerName*/
+//            const std::shared_ptr<RenderResponse>& response);
 
 private:
 

--- a/carta/cpp/core/Data/Image/Save/SaveService.h
+++ b/carta/cpp/core/Data/Image/Save/SaveService.h
@@ -9,6 +9,7 @@
 #include <QSize>
 #include <QImage>
 #include <QList>
+#include <QFile>
 #include <memory>
 #include "CartaLib/CartaLib.h"
 

--- a/carta/cpp/core/Data/Image/Save/SaveView.cpp
+++ b/carta/cpp/core/Data/Image/Save/SaveView.cpp
@@ -32,9 +32,9 @@ void SaveView::setRaster( const QImage & image ){
     m_raster = image;
 }
 
-void SaveView::setVectorGraphics( const Lib::IRemoteVGView::VGList & vglist ){
-    m_vgList = vglist;
-}
+//void SaveView::setVectorGraphics( const Lib::IRemoteVGView::VGList & vglist ){
+//    m_vgList = vglist;
+//}
 
 
 SaveView::~SaveView(){

--- a/carta/cpp/core/Data/Image/Save/SaveViewLayered.cpp
+++ b/carta/cpp/core/Data/Image/Save/SaveViewLayered.cpp
@@ -38,40 +38,40 @@ void SaveViewLayered::setVectorGraphicsLayer( int layer, const Carta::Lib::Vecto
 }
 
 
-void SaveViewLayered::paintLayers(){
-    // figure out the size of the buffer (max of the raster sizes)
-    QSize size( 1, 1 );
-    for ( auto & layer : m_rasterLayers ) {
-        size = size.expandedTo( layer.qimg.size() );
-    }
+//void SaveViewLayered::paintLayers(){
+//    // figure out the size of the buffer (max of the raster sizes)
+//    QSize size( 1, 1 );
+//    for ( auto & layer : m_rasterLayers ) {
+//        size = size.expandedTo( layer.qimg.size() );
+//    }
 
-    QImage buff( size, QImage::Format_ARGB32_Premultiplied );
-    buff.fill( QColor( 0, 0, 0, 255 ) );
+//    QImage buff( size, QImage::Format_ARGB32_Premultiplied );
+//    buff.fill( QColor( 0, 0, 0, 255 ) );
 
-    // now go through the layers and paint them on top of the last result
-    for ( auto & layer : m_rasterLayers ) {
-        Carta::Lib::IQImageCombiner::SharedPtr combiner = layer.combiner;
-        if ( ! combiner ) {
-            combiner = std::make_shared < Carta::Lib::DefaultCombiner > ();
-        }
-        combiner->combine( buff, layer.qimg );
-    }
+//    // now go through the layers and paint them on top of the last result
+//    for ( auto & layer : m_rasterLayers ) {
+//        Carta::Lib::IQImageCombiner::SharedPtr combiner = layer.combiner;
+//        if ( ! combiner ) {
+//            combiner = std::make_shared < Carta::Lib::DefaultCombiner > ();
+//        }
+//        combiner->combine( buff, layer.qimg );
+//    }
 
-    m_vgView-> setRaster( buff );
+//    m_vgView-> setRaster( buff );
 
-    // concatenate all VG lists into one
-    Carta::Lib::VectorGraphics::VGComposer composer;
-    for ( auto & vglayer : m_vgLayers ) {
-        composer.append < Carta::Lib::VectorGraphics::Entries::Reset > ();
-        composer.appendList( vglayer.vglist );
-    }
+//    // concatenate all VG lists into one
+//    Carta::Lib::VectorGraphics::VGComposer composer;
+//    for ( auto & vglayer : m_vgLayers ) {
+//        composer.append < Carta::Lib::VectorGraphics::Entries::Reset > ();
+//        composer.appendList( vglayer.vglist );
+//    }
 
-    // render the combined vector graphics list
-    m_vgView-> setVectorGraphics( composer.vgList() );
+//    // render the combined vector graphics list
+//    m_vgView-> setVectorGraphics( composer.vgList() );
 
-    // schedule repaint
-    m_vgView-> scheduleRepaint( );
-}
+//    // schedule repaint
+//    m_vgView-> scheduleRepaint( );
+//}
 
 
 SaveViewLayered::~SaveViewLayered(){

--- a/carta/cpp/core/Data/Image/Save/SaveViewLayered.h
+++ b/carta/cpp/core/Data/Image/Save/SaveViewLayered.h
@@ -28,7 +28,7 @@ class SaveViewLayered {
         /**
          * Combine the layers into an image.
          */
-        void paintLayers();
+//        void paintLayers();
 
         /**
          * Clear the layers.

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -175,17 +175,17 @@ QString Stack::_getCurrentId() const {
     return id;
 }
 
-QString Stack::_getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY) {
-    int dataIndex = _getIndexCurrent();
-    QString cursorText;
-    if ( dataIndex >= 0 ){
-        std::vector<int> frameIndices = _getFrameIndices();
-        QSize outputSize = m_stackDraw->getClientSize();
-        cursorText = m_children[dataIndex]->_getCursorText( isAutoClip, minPercent, maxPercent, mouseX, mouseY,
-                frameIndices, outputSize );
-    }
-    return cursorText;
-}
+//QString Stack::_getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY) {
+//    int dataIndex = _getIndexCurrent();
+//    QString cursorText;
+//    if ( dataIndex >= 0 ){
+//        std::vector<int> frameIndices = _getFrameIndices();
+//        QSize outputSize = m_stackDraw->getClientSize();
+//        cursorText = m_children[dataIndex]->_getCursorText( isAutoClip, minPercent, maxPercent, mouseX, mouseY,
+//                frameIndices, outputSize );
+//    }
+//    return cursorText;
+//}
 
 Carta::State::StateInterface Stack::_getDataGridState(){
     std::shared_ptr<DataGrid> dataGrid = _getDataGrid();
@@ -316,11 +316,11 @@ int Stack::_getIndexCurrent( ) const {
     return dataIndex;
 }
 
-QRectF Stack::_getInputRectangle( ) const {
-    QSize output = m_stackDraw->getClientSize();
-    QRectF rect = _getInputRect( output );
-    return rect;
-}
+//QRectF Stack::_getInputRectangle( ) const {
+//    QSize output = m_stackDraw->getClientSize();
+//    QRectF rect = _getInputRect( output );
+//    return rect;
+//}
 
 QStringList Stack::_getLayerIds( ) const {
     QStringList idList;
@@ -330,9 +330,9 @@ QStringList Stack::_getLayerIds( ) const {
     return idList;
 }
 
-QSize Stack::_getOutputSize() const {
-    return m_stackDraw->getClientSize();
-}
+//QSize Stack::_getOutputSize() const {
+//    return m_stackDraw->getClientSize();
+//}
 
 QString Stack::_getPixelVal( double x, double y) const {
     std::vector<int> frames = _getFrameIndices();
@@ -509,33 +509,33 @@ void Stack::_renderContext( double zoomFactor ){
     }
 }
 
-void Stack::_renderZoom( int mouseX, int mouseY, double zoomFactor ){
-    if ( m_imageDraws->isZoomView()){
-        bool validPt = false;
-        QPointF screenPt( mouseX, mouseY );
-        QSize outputSize = m_stackDraw->getClientSize();
-        QPointF panPt = _getImagePt( screenPt, outputSize, &validPt );
-        std::vector<int> frames =_getFrameIndices();
-        const Carta::Lib::KnownSkyCS& cs = _getCoordinateSystem();
-        std::shared_ptr<RenderRequest> request( new RenderRequest( frames, cs));
-        int gridIndex = _getIndexCurrent();
-        request->setTopIndex( gridIndex );
-        request->setRequestZoom( true );
-        request->setPan( panPt);
-        request->setZoom( zoomFactor );
-        if ( validPt ){
-            QList<std::shared_ptr<Layer> > datas = _getDrawChildren();
-            request->setData( datas );
-            m_imageDraws->render( request);
-        }
-        else {
-            //Clear the screen.
-            QList<std::shared_ptr<Layer> > datas;
-            request->setData( datas );
-            m_imageDraws->render( request );
-        }
-    }
-}
+//void Stack::_renderZoom( int mouseX, int mouseY, double zoomFactor ){
+//    if ( m_imageDraws->isZoomView()){
+//        bool validPt = false;
+//        QPointF screenPt( mouseX, mouseY );
+//        QSize outputSize = m_stackDraw->getClientSize();
+//        QPointF panPt = _getImagePt( screenPt, outputSize, &validPt );
+//        std::vector<int> frames =_getFrameIndices();
+//        const Carta::Lib::KnownSkyCS& cs = _getCoordinateSystem();
+//        std::shared_ptr<RenderRequest> request( new RenderRequest( frames, cs));
+//        int gridIndex = _getIndexCurrent();
+//        request->setTopIndex( gridIndex );
+//        request->setRequestZoom( true );
+//        request->setPan( panPt);
+//        request->setZoom( zoomFactor );
+//        if ( validPt ){
+//            QList<std::shared_ptr<Layer> > datas = _getDrawChildren();
+//            request->setData( datas );
+//            m_imageDraws->render( request);
+//        }
+//        else {
+//            //Clear the screen.
+//            QList<std::shared_ptr<Layer> > datas;
+//            request->setData( datas );
+//            m_imageDraws->render( request );
+//        }
+//    }
+//}
 
 QString Stack::_resetFrames( int val ){
 	//Set the image frame.
@@ -784,15 +784,15 @@ bool Stack::_setLayerName( const QString& id, const QString& name ){
     return nameSet;
 }
 
-bool Stack::_setLayersGrouped( bool grouped  ){
-	QSize clientSize = m_stackDraw->getClientSize();
-    bool operationPerformed = LayerGroup::_setLayersGrouped( grouped, clientSize);
-    if ( operationPerformed ){
-        emit viewLoad();
-        _saveState();
-    }
-    return operationPerformed;
-}
+//bool Stack::_setLayersGrouped( bool grouped  ){
+//	QSize clientSize = m_stackDraw->getClientSize();
+//    bool operationPerformed = LayerGroup::_setLayersGrouped( grouped, clientSize);
+//    if ( operationPerformed ){
+//        emit viewLoad();
+//        _saveState();
+//    }
+//    return operationPerformed;
+//}
 
 
 void Stack::_setMaskColor( const QString& id, int redAmount,
@@ -906,51 +906,51 @@ void Stack::_setZoomLevel( double zoomLevel, bool zoomPanAll ){
     emit viewLoad();
 }
 
-void Stack::_updatePan( double centerX , double centerY, bool zoomPanAll ){
-    if ( zoomPanAll ){
-        for ( std::shared_ptr<Layer> data : m_children ){
-            _updatePan( centerX, centerY, data );
-        }
-    }
-    else {
-        int dataIndex = _getIndexCurrent();
-        if ( dataIndex >= 0 ){
-            _updatePan( centerX, centerY, m_children[dataIndex] );
-        }
-    }
-    emit viewLoad();
-}
+//void Stack::_updatePan( double centerX , double centerY, bool zoomPanAll ){
+//    if ( zoomPanAll ){
+//        for ( std::shared_ptr<Layer> data : m_children ){
+//            _updatePan( centerX, centerY, data );
+//        }
+//    }
+//    else {
+//        int dataIndex = _getIndexCurrent();
+//        if ( dataIndex >= 0 ){
+//            _updatePan( centerX, centerY, m_children[dataIndex] );
+//        }
+//    }
+//    emit viewLoad();
+//}
 
-void Stack::_updatePan( double centerX , double centerY,
-        std::shared_ptr<Layer> data){
-    bool validImage = false;
-    QSize outputSize = m_stackDraw->getClientSize();
-    QPointF imagePt = data -> _getImagePt( { centerX, centerY }, outputSize, &validImage );
-    if ( validImage ){
-        double imageX = imagePt.x();
-        double imageY = imagePt.y();
-        data->_setPan( imageX, imageY );
-    }
-}
+//void Stack::_updatePan( double centerX , double centerY,
+//        std::shared_ptr<Layer> data){
+//    bool validImage = false;
+//    QSize outputSize = m_stackDraw->getClientSize();
+//    QPointF imagePt = data -> _getImagePt( { centerX, centerY }, outputSize, &validImage );
+//    if ( validImage ){
+//        double imageX = imagePt.x();
+//        double imageY = imagePt.y();
+//        data->_setPan( imageX, imageY );
+//    }
+//}
 
-void Stack::_updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel, double layerId){
-    if ( zoomPanAll ){
-        for (std::shared_ptr<Layer> data : m_children ){
-            _updatePanZoom( centerX, centerY, zoomFactor, data, zoomLevel );
-        }
-    }
-    else {
+//void Stack::_updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel, double layerId){
+//    if ( zoomPanAll ){
+//        for (std::shared_ptr<Layer> data : m_children ){
+//            _updatePanZoom( centerX, centerY, zoomFactor, data, zoomLevel );
+//        }
+//    }
+//    else {
 
-        int dataCount = m_children.size();
-        for ( int i = 0; i < dataCount; i++ ){
-            if (m_children[i]->_getLayerId() == QString::number(layerId)){
-                _updatePanZoom( centerX, centerY, zoomFactor, m_children[i], zoomLevel );
-                break;
-            }
-        }
-    }
-    emit viewLoad();
-}
+//        int dataCount = m_children.size();
+//        for ( int i = 0; i < dataCount; i++ ){
+//            if (m_children[i]->_getLayerId() == QString::number(layerId)){
+//                _updatePanZoom( centerX, centerY, zoomFactor, m_children[i], zoomLevel );
+//                break;
+//            }
+//        }
+//    }
+//    emit viewLoad();
+//}
 
 
 void Stack::updateZoom(double zoomFactor, bool zoomPanAll, double zoomLevel, double layerId){
@@ -993,46 +993,46 @@ void Stack::_updateZoom(double zoomFactor,
     data->_setZoom( newZoom );
 }
 
-void Stack::_updatePanZoom( double centerX, double centerY, double zoomFactor,
-         std::shared_ptr<Layer> data, double zoomLevel){
-    //Remember where the user clicked
-    QPointF clickPtScreen( centerX, centerY);
-    bool validImage = false;
-    QSize outputSize = m_stackDraw->getClientSize();
-    QPointF clickPtImageOld = data->_getImagePt( clickPtScreen, outputSize, &validImage );
-    if ( validImage ){
+//void Stack::_updatePanZoom( double centerX, double centerY, double zoomFactor,
+//         std::shared_ptr<Layer> data, double zoomLevel){
+//    //Remember where the user clicked
+//    QPointF clickPtScreen( centerX, centerY);
+//    bool validImage = false;
+//    QSize outputSize = m_stackDraw->getClientSize();
+//    QPointF clickPtImageOld = data->_getImagePt( clickPtScreen, outputSize, &validImage );
+//    if ( validImage ){
 
-        //Set the zoom
-        double newZoom = 1;
+//        //Set the zoom
+//        double newZoom = 1;
 
-        // Grimmer: to be compatible with the original logic and function, keep old way, zoomFactor
-        if (zoomLevel >=0) {
-            newZoom = zoomLevel;
-        } else {
-            double oldZoom = data->_getZoom();
-            if ( zoomFactor < 0 ) {
-                newZoom = oldZoom * 1.5625;
-            }
-            else {
-                newZoom = oldZoom * 0.64;
-            }
-        }
+//        // Grimmer: to be compatible with the original logic and function, keep old way, zoomFactor
+//        if (zoomLevel >=0) {
+//            newZoom = zoomLevel;
+//        } else {
+//            double oldZoom = data->_getZoom();
+//            if ( zoomFactor < 0 ) {
+//                newZoom = oldZoom * 1.5625;
+//            }
+//            else {
+//                newZoom = oldZoom * 0.64;
+//            }
+//        }
 
-        data->_setZoom( newZoom );
+//        data->_setZoom( newZoom );
 
-        // what is the new image pixel under the mouse cursor?
-        QSize outputSize = m_stackDraw->getClientSize();
-        QPointF clickPtImageNew = data ->_getImagePt( clickPtScreen, outputSize, &validImage );
+//        // what is the new image pixel under the mouse cursor?
+////        QSize outputSize = m_stackDraw->getClientSize();
+//        QPointF clickPtImageNew = data ->_getImagePt( clickPtScreen, outputSize, &validImage );
 
-        // calculate the difference
-        QPointF delta = clickPtImageOld - clickPtImageNew;
+//        // calculate the difference
+//        QPointF delta = clickPtImageOld - clickPtImageNew;
 
-        // add the delta to the current center
-        QPointF currCenter = data ->_getCenterPixel();
-        QPointF newCenter = currCenter + delta;
-        data->_setPan( newCenter.x(), newCenter.y() );
-    }
-}
+//        // add the delta to the current center
+//        QPointF currCenter = data ->_getCenterPixel();
+//        QPointF newCenter = currCenter + delta;
+//        data->_setPan( newCenter.x(), newCenter.y() );
+//    }
+//}
 
 
 

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -83,7 +83,7 @@ protected:
      */
     virtual bool _setLayerName( const QString& id, const QString& name ) Q_DECL_OVERRIDE;
 
-    virtual bool _setLayersGrouped( bool grouped  );
+//    virtual bool _setLayersGrouped( bool grouped  );
 
     virtual bool _setSelected( QStringList& names ) Q_DECL_OVERRIDE;
 
@@ -112,7 +112,7 @@ private:
     QStringList _getCoords( double x, double y,
                 Carta::Lib::KnownSkyCS system ) const;
 
-    QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY );
+//    QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY );
     Carta::State::StateInterface _getDataGridState();
 
     QList<std::shared_ptr<Layer> > _getDrawChildren() const;
@@ -123,7 +123,7 @@ private:
     std::vector<int> _getImageSlice() const;
     int _getIndex( const QString& layerId) const;
     QString _getPixelVal( double x, double y) const;
-    QRectF _getInputRectangle() const;
+//    QRectF _getInputRectangle() const;
      QList<std::shared_ptr<Region> > _getRegions() const;
 
      int _getSelectImageIndex() const;
@@ -139,7 +139,7 @@ private:
       * Returns the size in pixels of the main image display.
       * @return - the size in pixels of the main image display.
       */
-     QSize _getOutputSize() const;
+//     QSize _getOutputSize() const;
 
     void _gridChanged( const Carta::State::StateInterface& state, bool applyAll);
 
@@ -151,7 +151,7 @@ private:
     		bool recomputeClipsOnNewFrame, double minClipPercentile, double maxClipPercentile);
     void _renderAll(bool recomputeClipsOnNewFrame, double minClipPercentile, double maxClipPercentile);
     void _renderContext( double zoomFactor );
-    void _renderZoom( int mouseX, int mouseY, double factor );
+//    void _renderZoom( int mouseX, int mouseY, double factor );
 
     QString _reorderImages( const std::vector<int> & indices );
     QString _resetFrames( int val);
@@ -199,13 +199,13 @@ private:
     void _setZoomLevel( double zoomLevel, bool zoomPanAll );
 
 
-    void _updatePan( double centerX , double centerY, bool zoomPanAll );
-    void _updatePan( double centerX , double centerY,
-            std::shared_ptr<Layer> data);
+//    void _updatePan( double centerX , double centerY, bool zoomPanAll );
+//    void _updatePan( double centerX , double centerY,
+//            std::shared_ptr<Layer> data);
 
-    void _updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel, double layerId);
-    void _updatePanZoom( double centerX, double centerY, double zoomFactor,
-            std::shared_ptr<Layer> data, double zoomLevel );
+//    void _updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel, double layerId);
+//    void _updatePanZoom( double centerX, double centerY, double zoomFactor,
+//            std::shared_ptr<Layer> data, double zoomLevel );
 
     void updateZoom(double zoomFactor, bool zoomPanAll, double zoomLevel, double layerId);
     void _updateZoom(double zoomFactor, std::shared_ptr<Layer> data, double zoomLevel);

--- a/carta/cpp/core/Data/Plotter/Plot2DManager.cpp
+++ b/carta/cpp/core/Data/Plotter/Plot2DManager.cpp
@@ -10,6 +10,9 @@
 #include "State/UtilState.h"
 #include <QDir>
 #include <QDebug>
+#include <QPoint>
+#include <QPointF>
+#include <QSize>
 
 namespace Carta {
 
@@ -35,7 +38,7 @@ Plot2DManager::Plot2DManager( const QString& path, const QString& id ):
     _initializeDefaultState();
     _initializeCallbacks();
 
-    m_view.reset( new ImageView( path, QColor("yellow"), QImage(), &m_stateMouse));
+//    m_view.reset( new ImageView( path, QColor("yellow"), QImage(), &m_stateMouse));
     connect( m_view.get(), SIGNAL(resize(const QSize&)), this, SLOT(_updateSize(const QSize&)));
     registerView(m_view.get());
     m_selectionEnabled = false;
@@ -356,12 +359,12 @@ void Plot2DManager::setAxisXRange( double min, double max ){
 }
 
 
-void Plot2DManager::setColor( QColor curveColor, const QString& id ){
-    // if ( m_plotGenerator ){
-    //     m_plotGenerator->setColor( curveColor, id);
-    //     updatePlot();
-    // }
-}
+//void Plot2DManager::setColor( QColor curveColor, const QString& id ){
+//     if ( m_plotGenerator ){
+//         m_plotGenerator->setColor( curveColor, id);
+//         updatePlot();
+//     }
+//}
 
 
 void Plot2DManager::setColored( bool colored, const QString& id, int index ){

--- a/carta/cpp/core/Data/Plotter/Plot2DManager.h
+++ b/carta/cpp/core/Data/Plotter/Plot2DManager.h
@@ -227,7 +227,7 @@ public:
      * @param id - an identifier for a particular data set.
      */
     //Note:  this refers to using a single color for the entire data set.
-    void setColor( QColor curveColor, const QString& id = QString() );
+//    void setColor( QColor curveColor, const QString& id = QString() );
 
     /**
      * Set whether or not the graph should be colored.

--- a/carta/cpp/core/Data/Profile/Profiler.cpp
+++ b/carta/cpp/core/Data/Profile/Profiler.cpp
@@ -2705,7 +2705,7 @@ QStringList Profiler::setCurveColor( const QString& name, int redAmount, int gre
                 m_plotCurves[index]->setColor( curveColor );
                 _saveCurveState( index );
                 m_stateData.flushState();
-                m_plotManager->setColor( curveColor, name );
+//                m_plotManager->setColor( curveColor, name );
             }
         }
         else {
@@ -3596,7 +3596,7 @@ QString Profiler::setZoomRangePercent( double zoomMinPercent, double zoomMaxPerc
 void Profiler::timerEvent( QTimerEvent* /*event*/ ){
     Controller* controller = _getControllerSelected();
     if ( controller ){
-        controller->_setFrameAxis( m_oldFrame, Carta::Lib::AxisInfo::KnownType::SPECTRAL );
+//        controller->_setFrameAxis( m_oldFrame, Carta::Lib::AxisInfo::KnownType::SPECTRAL );
         _updateChannel( controller, Carta::Lib::AxisInfo::KnownType::SPECTRAL );
         if ( m_oldFrame < m_currentFrame ){
             m_oldFrame++;

--- a/carta/cpp/core/Globals.h
+++ b/carta/cpp/core/Globals.h
@@ -13,9 +13,11 @@
 #pragma once
 
 #include "PluginManager.h"
+#include "IConnector.h"
+#include "IPlatform.h"
 
-class IConnector;
-class IPlatform;
+//class IConnector;
+//class IPlatform;
 namespace CmdLine { class ParsedInfo; }
 namespace MainConfig { class ParsedInfo; }
 

--- a/carta/cpp/core/Hacks/HackViewer.cpp
+++ b/carta/cpp/core/Hacks/HackViewer.cpp
@@ -168,7 +168,7 @@ HackViewer::start()
     prefixedSetState( "knownSkyCS/count", "5" );
 
     // managed layer demo
-    m_lvDemo.reset( new LayeredViewDemo( this));
+//    m_lvDemo.reset( new LayeredViewDemo( this));
 
 #ifdef DONT_COMPILE
     // layered view 2 stuff

--- a/carta/cpp/core/Hacks/HackViewer.h
+++ b/carta/cpp/core/Hacks/HackViewer.h
@@ -68,7 +68,7 @@ protected:
     Carta::Hacks::ImageViewController::UniquePtr m_imageViewController;
     std::vector < Carta::Lib::PixelPipeline::IColormapNamed::SharedPtr > m_allColormaps;
 
-    LayeredViewDemo::UniquePtr m_lvDemo = nullptr;
+//    LayeredViewDemo::UniquePtr m_lvDemo = nullptr;
 
 };
 }

--- a/carta/cpp/core/Hacks/ILayeredView.h
+++ b/carta/cpp/core/Hacks/ILayeredView.h
@@ -127,25 +127,25 @@ public:
 signals:
 
     // keyboard events
-    void
-    key( std::shared_ptr < QKeyEvent > );
+//    void
+//    key( std::shared_ptr < QKeyEvent > );
 
-    // active mouse events
-    void
-    mouseClick( std::shared_ptr < QMouseEvent > );
+//    // active mouse events
+//    void
+//    mouseClick( std::shared_ptr < QMouseEvent > );
 
-    void
-    mouseDown( std::shared_ptr < QMouseEvent > );
+//    void
+//    mouseDown( std::shared_ptr < QMouseEvent > );
 
-    void
-    mouseUp( std::shared_ptr < QMouseEvent > );
+//    void
+//    mouseUp( std::shared_ptr < QMouseEvent > );
 
-    void
-    mouseDrag( std::shared_ptr < QMouseEvent > );
+//    void
+//    mouseDrag( std::shared_ptr < QMouseEvent > );
 
-    // passive mouse events
-    void
-    mouseMove( std::shared_ptr < QMouseEvent > );
+//    // passive mouse events
+//    void
+//    mouseMove( std::shared_ptr < QMouseEvent > );
 };
 }
 }

--- a/carta/cpp/core/Hacks/ImageViewController.cpp
+++ b/carta/cpp/core/Hacks/ImageViewController.cpp
@@ -307,11 +307,11 @@ ImageViewController::size()
     return m_renderBuffer.size();
 }
 
-const QImage &
-ImageViewController::getBuffer()
-{
-    return m_renderBuffer;
-}
+//const QImage &
+//ImageViewController::getBuffer()
+//{
+//    return m_renderBuffer;
+//}
 
 void
 ImageViewController::setCmapInvert( bool flag )

--- a/carta/cpp/core/Hacks/ImageViewController.h
+++ b/carta/cpp/core/Hacks/ImageViewController.h
@@ -213,20 +213,20 @@ public:
     size() override;
 
     /// IView interface
-    virtual const QImage &
-    getBuffer() override;
+//    virtual const QImage &
+//    getBuffer() override;
 
     /// IView interface
     virtual void
     handleResizeRequest( const QSize & size ) override;
 
-    /// IView interface
-    virtual void
-    handleMouseEvent( const QMouseEvent & ) override { }
+//    /// IView interface
+//    virtual void
+//    handleMouseEvent( const QMouseEvent & ) override { }
 
-    /// IView interface
-    virtual void
-    handleKeyEvent( const QKeyEvent & ) override { }
+//    /// IView interface
+//    virtual void
+//    handleKeyEvent( const QKeyEvent & ) override { }
 
     /// IView interface
     virtual void

--- a/carta/cpp/core/Hacks/LayeredViewDemo.cpp
+++ b/carta/cpp/core/Hacks/LayeredViewDemo.cpp
@@ -7,8 +7,8 @@
 #include "CartaLib/VectorGraphics/VGList.h"
 #include "CartaLib/Regions/IRegion.h"
 #include "InteractiveShapes.h"
-#include <QPainter>
-#include <QImage>
+//#include <QPainter>
+//#include <QImage>
 #include <QTimer>
 #include <QTime>
 #include <QVector2D>
@@ -65,68 +65,68 @@ private:
         p.drawEllipse( m_center,
                        40, 60 );
         p.end();
-        setRaster( img );
+//        setRaster( img );
     }
 
     QPointF m_center;
     QSize m_clientSize = QSize( 100, 100 );
 };
 
-class RepelLayer : public Carta::Hacks::ManagedLayerBase
-{
-    Q_OBJECT
+//class RepelLayer : public Carta::Hacks::ManagedLayerBase
+//{
+//    Q_OBJECT
 
-public:
+//public:
 
-    RepelLayer( Carta::Hacks::ManagedLayerView * mlv, QString layerName )
-        : Carta::Hacks::ManagedLayerBase( mlv, layerName )
-    {
-        onResize( { 100, 100 } );
-    }
+//    RepelLayer( Carta::Hacks::ManagedLayerView * mlv, QString layerName )
+//        : Carta::Hacks::ManagedLayerBase( mlv, layerName )
+//    {
+//        onResize( { 100, 100 } );
+//    }
 
-private:
+//private:
 
-    virtual void
-    onInputEvent( Carta::Lib::InputEvent & ev ) override
-    {
-        Carta::Lib::InputEvents::HoverEvent hover( ev );
-        double speed = 0.01;
-        if ( hover.isValid() ) {
-            m_center = ( 1 - speed ) * m_center + speed * hover.pos();
-            QVector2D dv = QVector2D( m_center ) - QVector2D( hover.pos() );
-            double dist = dv.length() / 100.0;
-            double dd = 10.0 / ( dist + 1 ) + 10;
-            m_size = QSize( dd, dd );
+//    virtual void
+//    onInputEvent( Carta::Lib::InputEvent & ev ) override
+//    {
+//        Carta::Lib::InputEvents::HoverEvent hover( ev );
+//        double speed = 0.01;
+//        if ( hover.isValid() ) {
+//            m_center = ( 1 - speed ) * m_center + speed * hover.pos();
+//            QVector2D dv = QVector2D( m_center ) - QVector2D( hover.pos() );
+//            double dist = dv.length() / 100.0;
+//            double dd = 10.0 / ( dist + 1 ) + 10;
+//            m_size = QSize( dd, dd );
 
-            rerender();
-        }
-    }
+//            rerender();
+//        }
+//    }
 
-    virtual void
-    onResize( const QSize & size ) override
-    {
-        m_clientSize = size;
-        m_center = QPointF( size.width() / 2.0, size.height() / 2.0 );
-        rerender();
-    }
+//    virtual void
+//    onResize( const QSize & size ) override
+//    {
+//        m_clientSize = size;
+//        m_center = QPointF( size.width() / 2.0, size.height() / 2.0 );
+//        rerender();
+//    }
 
-    void
-    rerender()
-    {
-        Carta::Lib::VectorGraphics::VGComposer comp;
+//    void
+//    rerender()
+//    {
+//        Carta::Lib::VectorGraphics::VGComposer comp;
 
-        comp.append < vge::SetPenColor > ( "yellow" );
-        comp.append < vge::SetPenWidth > ( 2.0 );
-        QRectF rect( m_center, m_size );
-        rect.moveCenter( m_center );
-        comp.append < vge::DrawRect > ( rect );
-        setVG( comp.vgList() );
-    }
+//        comp.append < vge::SetPenColor > ( "yellow" );
+//        comp.append < vge::SetPenWidth > ( 2.0 );
+//        QRectF rect( m_center, m_size );
+//        rect.moveCenter( m_center );
+//        comp.append < vge::DrawRect > ( rect );
+//        setVG( comp.vgList() );
+//    }
 
-    QPointF m_center;
-    QSizeF m_size = QSize( 10.0, 10.0 );
-    QSize m_clientSize = QSize( 100, 100 );
-};
+//    QPointF m_center;
+//    QSizeF m_size = QSize( 10.0, 10.0 );
+//    QSize m_clientSize = QSize( 100, 100 );
+//};
 
 class ControlPoint
 {
@@ -181,88 +181,88 @@ private:
     std::vector < ControlPoint::SharedPtr > m_cps;
 };
 
-class ControlPointLayer : public Carta::Hacks::ManagedLayerBase
-{
-    Q_OBJECT
+//class ControlPointLayer : public Carta::Hacks::ManagedLayerBase
+//{
+//    Q_OBJECT
 
-public:
+//public:
 
-    ControlPointLayer( Carta::Hacks::ManagedLayerView * mlv, QString layerName )
-        : Carta::Hacks::ManagedLayerBase( mlv, layerName )
-    {
-        onResize( { 100, 100 } );
-    }
+//    ControlPointLayer( Carta::Hacks::ManagedLayerView * mlv, QString layerName )
+//        : Carta::Hacks::ManagedLayerBase( mlv, layerName )
+//    {
+//        onResize( { 100, 100 } );
+//    }
 
-    void
-    setCPSet( ControlPointSet::SharedPtr set )
-    {
-        m_cpSet = set;
-        rerender();
-    }
+//    void
+//    setCPSet( ControlPointSet::SharedPtr set )
+//    {
+//        m_cpSet = set;
+//        rerender();
+//    }
 
-    ControlPointSet::SharedPtr
-    cpSet() { return m_cpSet; }
+//    ControlPointSet::SharedPtr
+//    cpSet() { return m_cpSet; }
 
-signals:
+//signals:
 
-private:
+//private:
 
-    ControlPointSet::SharedPtr m_cpSet = std::make_shared < ControlPointSet > ();
-    qint64 m_selectedPointIndex = - 1;
+//    ControlPointSet::SharedPtr m_cpSet = std::make_shared < ControlPointSet > ();
+//    qint64 m_selectedPointIndex = - 1;
 
-    virtual void
-    onInputEvent( Carta::Lib::InputEvent & ev ) override
-    {
-        Carta::Lib::InputEvents::HoverEvent hover( ev );
-        if ( hover.isValid() ) {
-            m_selectedPointIndex = - 1;
-            const auto & cpArray = m_cpSet-> pts();
-            for ( qint64 i = 0 ; i < qint64( cpArray.size() ) ; i++ ) {
-                const auto & p = cpArray[i];
-                QVector2D dv = QVector2D( p-> position() ) - QVector2D( hover.pos() );
-                double dist = dv.length();
-                if ( dist < 10 ) {
-                    m_selectedPointIndex = i;
-                }
-            }
-            rerender();
-        }
-    }
+//    virtual void
+//    onInputEvent( Carta::Lib::InputEvent & ev ) override
+//    {
+//        Carta::Lib::InputEvents::HoverEvent hover( ev );
+//        if ( hover.isValid() ) {
+//            m_selectedPointIndex = - 1;
+//            const auto & cpArray = m_cpSet-> pts();
+//            for ( qint64 i = 0 ; i < qint64( cpArray.size() ) ; i++ ) {
+//                const auto & p = cpArray[i];
+//                QVector2D dv = QVector2D( p-> position() ) - QVector2D( hover.pos() );
+//                double dist = dv.length();
+//                if ( dist < 10 ) {
+//                    m_selectedPointIndex = i;
+//                }
+//            }
+//            rerender();
+//        }
+//    }
 
-    virtual void
-    onResize( const QSize & size ) override
-    {
-        m_clientSize = size;
-        rerender();
-    } // onResize
+//    virtual void
+//    onResize( const QSize & size ) override
+//    {
+//        m_clientSize = size;
+//        rerender();
+//    } // onResize
 
-    void
-    rerender()
-    {
-        Carta::Lib::VectorGraphics::VGComposer comp;
+//    void
+//    rerender()
+//    {
+//        Carta::Lib::VectorGraphics::VGComposer comp;
 
-        comp.append < vge::SetPenColor > ( "red" );
-        const auto & cpArray = m_cpSet-> pts();
+//        comp.append < vge::SetPenColor > ( "red" );
+//        const auto & cpArray = m_cpSet-> pts();
 
-        for ( qint64 i = 0 ; i < qint64( cpArray.size() ) ; i++ ) {
-            if ( i == m_selectedPointIndex ) {
-                comp.append < vge::SetPenWidth > ( 2.0 );
-            }
-            else {
-                comp.append < vge::SetPenWidth > ( 1.0 );
-            }
-            const auto & p = cpArray[i];
-            QRectF rect( p-> position(), m_size );
-            rect.moveCenter( p-> position() );
-            comp.append < vge::DrawRect > ( rect );
-        }
+//        for ( qint64 i = 0 ; i < qint64( cpArray.size() ) ; i++ ) {
+//            if ( i == m_selectedPointIndex ) {
+//                comp.append < vge::SetPenWidth > ( 2.0 );
+//            }
+//            else {
+//                comp.append < vge::SetPenWidth > ( 1.0 );
+//            }
+//            const auto & p = cpArray[i];
+//            QRectF rect( p-> position(), m_size );
+//            rect.moveCenter( p-> position() );
+//            comp.append < vge::DrawRect > ( rect );
+//        }
 
-        setVG( comp.vgList() );
-    } // rerender
+//        setVG( comp.vgList() );
+//    } // rerender
 
-    QSizeF m_size = QSize( 10.0, 10.0 );
-    QSize m_clientSize = QSize( 100, 100 );
-};
+//    QSizeF m_size = QSize( 10.0, 10.0 );
+//    QSize m_clientSize = QSize( 100, 100 );
+//};
 
 namespace editable
 {
@@ -835,188 +835,188 @@ private:
 /// a region set
 ///
 /// All actual work is done via EditableRegionsController
-class RegionEditorLayer : public Carta::Hacks::ManagedLayerBase
-{
-    Q_OBJECT
-    CLASS_BOILERPLATE( RegionEditorLayer );
+//class RegionEditorLayer : public Carta::Hacks::ManagedLayerBase
+//{
+//    Q_OBJECT
+//    CLASS_BOILERPLATE( RegionEditorLayer );
 
-public:
+//public:
 
-    RegionEditorLayer( Carta::Hacks::ManagedLayerView * mlv, QString layerName )
-        : Carta::Hacks::ManagedLayerBase( mlv, layerName )
-    {
-        m_editableRegionsController.reset( new EditableRegionsController );
-    }
+//    RegionEditorLayer( Carta::Hacks::ManagedLayerView * mlv, QString layerName )
+//        : Carta::Hacks::ManagedLayerBase( mlv, layerName )
+//    {
+//        m_editableRegionsController.reset( new EditableRegionsController );
+//    }
 
-    /// set the region set model on which this layer will operate
-    void
-    setRegionSetModel( RegionSetModel::SharedPtr regionSetModel )
-    {
-        m_regionSetModel = regionSetModel;
+//    /// set the region set model on which this layer will operate
+//    void
+//    setRegionSetModel( RegionSetModel::SharedPtr regionSetModel )
+//    {
+//        m_regionSetModel = regionSetModel;
 
-        // disconnect the previous model (if any)
-        if ( m_regionSetModelConnection ) {
-            disconnect( m_regionSetModelConnection );
-        }
+//        // disconnect the previous model (if any)
+//        if ( m_regionSetModelConnection ) {
+//            disconnect( m_regionSetModelConnection );
+//        }
 
-        // connect the new model
-        m_regionSetModelConnection =
-            connect( regionSetModel.get(), & RegionSetModel::changed,
-                     this, & Me::regionSetModelCB );
+//        // connect the new model
+//        m_regionSetModelConnection =
+//            connect( regionSetModel.get(), & RegionSetModel::changed,
+//                     this, & Me::regionSetModelCB );
 
-        // tell the editable regions controller we have a new region set
-        m_editableRegionsController-> setRegionSet( m_regionSetModel-> regionSet() );
-    }
+//        // tell the editable regions controller we have a new region set
+//        m_editableRegionsController-> setRegionSet( m_regionSetModel-> regionSet() );
+//    }
 
-    /// get the region set model on which we are operating
-    RegionSetModel::SharedPtr
-    regionSetModel()
-    {
-        return m_regionSetModel;
-    }
+//    /// get the region set model on which we are operating
+//    RegionSetModel::SharedPtr
+//    regionSetModel()
+//    {
+//        return m_regionSetModel;
+//    }
 
-signals:
+//signals:
 
-private slots:
+//private slots:
 
-    // callback for region set model
-    void
-    regionSetModelCB( SourceID id )
-    {
-        // if we originated this update, ignore it
-        if ( id == m_sourceId ) { return; }
+//    // callback for region set model
+//    void
+//    regionSetModelCB( SourceID id )
+//    {
+//        // if we originated this update, ignore it
+//        if ( id == m_sourceId ) { return; }
 
-        // otherwise tell the controller about the new region set
-        m_editableRegionsController-> setRegionSet( m_regionSetModel-> regionSet() );
-    }
+//        // otherwise tell the controller about the new region set
+//        m_editableRegionsController-> setRegionSet( m_regionSetModel-> regionSet() );
+//    }
 
-private:
+//private:
 
-    virtual void
-    onResize( const QSize & size ) override
-    {
-        Q_UNUSED( size );
-        rerender();
-    }
+//    virtual void
+//    onResize( const QSize & size ) override
+//    {
+//        Q_UNUSED( size );
+//        rerender();
+//    }
 
-    void
-    rerender()
-    {
-        // display whatever the editable regions controller displays
-        Carta::Lib::VectorGraphics::VGList vgList
-            = m_editableRegionsController-> vgList();
+//    void
+//    rerender()
+//    {
+//        // display whatever the editable regions controller displays
+//        Carta::Lib::VectorGraphics::VGList vgList
+//            = m_editableRegionsController-> vgList();
 
-        setVG( vgList );
-    }
+//        setVG( vgList );
+//    }
 
-    virtual void
-    onInputEvent( Carta::Lib::InputEvent & ev ) override
-    {
-        // deliver the event to editable regions controller
-        m_editableRegionsController-> handleEvent( ev );
+//    virtual void
+//    onInputEvent( Carta::Lib::InputEvent & ev ) override
+//    {
+//        // deliver the event to editable regions controller
+//        m_editableRegionsController-> handleEvent( ev );
 
-        // check if we need to update vg
-        if ( m_editableRegionsController-> hasNewVG() ) {
-            setVG( m_editableRegionsController-> vgList() );
-        }
+//        // check if we need to update vg
+//        if ( m_editableRegionsController-> hasNewVG() ) {
+//            setVG( m_editableRegionsController-> vgList() );
+//        }
 
-        // was the region set updated? if yes, let the region set model signal the update
-        if ( m_editableRegionsController-> wasRegionSetUpdated() ) {
-            // set the source ID to us, so we can ignore this update
-            m_regionSetModel-> scheduleUpdateSignal( m_sourceId );
-        }
-    } // onInputEvent
+//        // was the region set updated? if yes, let the region set model signal the update
+//        if ( m_editableRegionsController-> wasRegionSetUpdated() ) {
+//            // set the source ID to us, so we can ignore this update
+//            m_regionSetModel-> scheduleUpdateSignal( m_sourceId );
+//        }
+//    } // onInputEvent
 
-    RegionSetModel::SharedPtr m_regionSetModel = nullptr;
-    QMetaObject::Connection m_regionSetModelConnection;
+//    RegionSetModel::SharedPtr m_regionSetModel = nullptr;
+//    QMetaObject::Connection m_regionSetModelConnection;
 
-    EditableRegionsController::UniquePtr m_editableRegionsController = nullptr;
-    SourceID m_sourceId = getUniqueSourceID();
-};
+//    EditableRegionsController::UniquePtr m_editableRegionsController = nullptr;
+//    SourceID m_sourceId = getUniqueSourceID();
+//};
 
-class EditableLayer : public Carta::Hacks::ManagedLayerBase
-{
-    Q_OBJECT
-    CLASS_BOILERPLATE( EditableLayer );
+//class EditableLayer : public Carta::Hacks::ManagedLayerBase
+//{
+//    Q_OBJECT
+//    CLASS_BOILERPLATE( EditableLayer );
 
-public:
+//public:
 
-    EditableLayer( Carta::Hacks::ManagedLayerView * mlv, QString layerName )
-        : Carta::Hacks::ManagedLayerBase( mlv, layerName )
-    {
-        onResize( QSize( 100, 100 ) );
-    }
+//    EditableLayer( Carta::Hacks::ManagedLayerView * mlv, QString layerName )
+//        : Carta::Hacks::ManagedLayerBase( mlv, layerName )
+//    {
+//        onResize( QSize( 100, 100 ) );
+//    }
 
-    void
-    setCPSet( ControlPointSet::SharedPtr set )
-    {
-        m_cpSet = set;
-        rerender();
-    }
+//    void
+//    setCPSet( ControlPointSet::SharedPtr set )
+//    {
+//        m_cpSet = set;
+//        rerender();
+//    }
 
-    ControlPointSet::SharedPtr
-    cpSet() { return m_cpSet; }
+//    ControlPointSet::SharedPtr
+//    cpSet() { return m_cpSet; }
 
-signals:
+//signals:
 
-private:
+//private:
 
-    ControlPointSet::SharedPtr m_cpSet = std::make_shared < ControlPointSet > ();
-    qint64 m_selectedPointIndex = - 1;
+//    ControlPointSet::SharedPtr m_cpSet = std::make_shared < ControlPointSet > ();
+//    qint64 m_selectedPointIndex = - 1;
 
-    virtual void
-    onInputEvent( Carta::Lib::InputEvent & ev ) override
-    {
-        Carta::Lib::InputEvents::HoverEvent hover( ev );
-        if ( hover.isValid() ) {
-            m_selectedPointIndex = - 1;
-            const auto & cpArray = m_cpSet-> pts();
-            for ( qint64 i = 0 ; i < qint64( cpArray.size() ) ; i++ ) {
-                const auto & p = cpArray[i];
-                QVector2D dv = QVector2D( p-> position() ) - QVector2D( hover.pos() );
-                double dist = dv.length();
-                if ( dist < 10 ) {
-                    m_selectedPointIndex = i;
-                }
-            }
-            rerender();
-        }
-    }
+//    virtual void
+//    onInputEvent( Carta::Lib::InputEvent & ev ) override
+//    {
+//        Carta::Lib::InputEvents::HoverEvent hover( ev );
+//        if ( hover.isValid() ) {
+//            m_selectedPointIndex = - 1;
+//            const auto & cpArray = m_cpSet-> pts();
+//            for ( qint64 i = 0 ; i < qint64( cpArray.size() ) ; i++ ) {
+//                const auto & p = cpArray[i];
+//                QVector2D dv = QVector2D( p-> position() ) - QVector2D( hover.pos() );
+//                double dist = dv.length();
+//                if ( dist < 10 ) {
+//                    m_selectedPointIndex = i;
+//                }
+//            }
+//            rerender();
+//        }
+//    }
 
-    virtual void
-    onResize( const QSize & size ) override
-    {
-        m_clientSize = size;
-        rerender();
-    } // onResize
+//    virtual void
+//    onResize( const QSize & size ) override
+//    {
+//        m_clientSize = size;
+//        rerender();
+//    } // onResize
 
-    void
-    rerender()
-    {
-        Carta::Lib::VectorGraphics::VGComposer comp;
+//    void
+//    rerender()
+//    {
+//        Carta::Lib::VectorGraphics::VGComposer comp;
 
-        comp.append < vge::SetPenColor > ( "red" );
-        const auto & cpArray = m_cpSet-> pts();
+//        comp.append < vge::SetPenColor > ( "red" );
+//        const auto & cpArray = m_cpSet-> pts();
 
-        for ( qint64 i = 0 ; i < qint64( cpArray.size() ) ; i++ ) {
-            if ( i == m_selectedPointIndex ) {
-                comp.append < vge::SetPenWidth > ( 2.0 );
-            }
-            else {
-                comp.append < vge::SetPenWidth > ( 1.0 );
-            }
-            const auto & p = cpArray[i];
-            QRectF rect( p-> position(), m_size );
-            rect.moveCenter( p-> position() );
-            comp.append < vge::DrawRect > ( rect );
-        }
+//        for ( qint64 i = 0 ; i < qint64( cpArray.size() ) ; i++ ) {
+//            if ( i == m_selectedPointIndex ) {
+//                comp.append < vge::SetPenWidth > ( 2.0 );
+//            }
+//            else {
+//                comp.append < vge::SetPenWidth > ( 1.0 );
+//            }
+//            const auto & p = cpArray[i];
+//            QRectF rect( p-> position(), m_size );
+//            rect.moveCenter( p-> position() );
+//            comp.append < vge::DrawRect > ( rect );
+//        }
 
-        setVG( comp.vgList() );
-    } // rerender
+//        setVG( comp.vgList() );
+//    } // rerender
 
-    QSizeF m_size = QSize( 10.0, 10.0 );
-    QSize m_clientSize = QSize( 100, 100 );
-};
+//    QSizeF m_size = QSize( 10.0, 10.0 );
+//    QSize m_clientSize = QSize( 100, 100 );
+//};
 
 void
 EditableCircle::do_editModeChanged()
@@ -1210,7 +1210,7 @@ private:
         p.setPen( QPen( QColor( "yellow" ), 1 ) );
         p.drawLine( m_center, a2p( time.second() / 60.0 * M_PI * 2, m_radius - 2 ) );
         p.end();
-        setRaster( img );
+//        setRaster( img );
     } // rerender
 
     static QVector2D
@@ -1370,102 +1370,102 @@ private:
     Carta::Hacks::ManagedLayerView * m_mlv = nullptr;
 };
 
-namespace Carta
-{
-namespace Hacks
-{
-struct LayeredViewDemo::Pimpl {
-    LayeredViewController::UniquePtr lvc = nullptr;
-    ManagedLayerView::UniquePtr mlv = nullptr;
-};
+//namespace Carta
+//{
+//namespace Hacks
+//{
+//struct LayeredViewDemo::Pimpl {
+//    LayeredViewController::UniquePtr lvc = nullptr;
+//    ManagedLayerView::UniquePtr mlv = nullptr;
+//};
 
-LayeredViewDemo::LayeredViewDemo( QObject * parent ) : QObject( parent )
-{
-    m_pimpl = new Pimpl;
+//LayeredViewDemo::LayeredViewDemo( QObject * parent ) : QObject( parent )
+//{
+//    m_pimpl = new Pimpl;
 
-    m_pimpl-> mlv.reset( new ManagedLayerView( "mlv1", Globals::instance()->connector(), this ) );
+//    m_pimpl-> mlv.reset( new ManagedLayerView( "mlv1", Globals::instance()->connector(), this ) );
 
-    auto mlvRaw = m_pimpl-> mlv.get();
+//    auto mlvRaw = m_pimpl-> mlv.get();
 
-//    EyesLayer * eyes1 = new EyesLayer( mlvRaw, "ellipse1" );
-    ClockLayer * clockLayer = new ClockLayer( mlvRaw, "clock" );
-    Q_UNUSED( clockLayer);
+////    EyesLayer * eyes1 = new EyesLayer( mlvRaw, "ellipse1" );
+//    ClockLayer * clockLayer = new ClockLayer( mlvRaw, "clock" );
+//    Q_UNUSED( clockLayer);
 
-//    RepelLayer * repel1 = new RepelLayer( mlvRaw, "Repel1" );
-//    EyesLayer * eyes2 = new EyesLayer( mlvRaw, "ellipse2" );
+////    RepelLayer * repel1 = new RepelLayer( mlvRaw, "Repel1" );
+////    EyesLayer * eyes2 = new EyesLayer( mlvRaw, "ellipse2" );
 
-    /*
-    ControlPointLayer * cplayer = new ControlPointLayer( mlvRaw, "cplayer" );
-    ControlPointSet::SharedPtr cpset = std::make_shared < ControlPointSet > ();
-    ControlPoint::SharedPtr cp1;
-    cp1 = std::make_shared < ControlPoint > ();
-    cp1-> setPosition( QPointF( 10, 20 ) );
-    cpset->addPoint( cp1 );
-    cp1 = std::make_shared < ControlPoint > ();
-    cp1-> setPosition( QPointF( 30, 10 ) );
-    cpset->addPoint( cp1 );
-    cplayer-> setCPSet( cpset );
-*/
+//    /*
+//    ControlPointLayer * cplayer = new ControlPointLayer( mlvRaw, "cplayer" );
+//    ControlPointSet::SharedPtr cpset = std::make_shared < ControlPointSet > ();
+//    ControlPoint::SharedPtr cp1;
+//    cp1 = std::make_shared < ControlPoint > ();
+//    cp1-> setPosition( QPointF( 10, 20 ) );
+//    cpset->addPoint( cp1 );
+//    cp1 = std::make_shared < ControlPoint > ();
+//    cp1-> setPosition( QPointF( 30, 10 ) );
+//    cpset->addPoint( cp1 );
+//    cplayer-> setCPSet( cpset );
+//*/
 
-    // ==================================================================================
-    // region demo
-    // ==================================================================================
+//    // ==================================================================================
+//    // region demo
+//    // ==================================================================================
 
-    struct RegionDemo {
-        editable::RegionSet::SharedPtr regionSet = nullptr;
-        editable::RegionSetModel::SharedPtr regionSetModel = nullptr;
-    };
+//    struct RegionDemo {
+//        editable::RegionSet::SharedPtr regionSet = nullptr;
+//        editable::RegionSetModel::SharedPtr regionSetModel = nullptr;
+//    };
 
-    // intentional memory leak to make sure our smart pointers don't go out of scope
-    RegionDemo & regionDemo = * new RegionDemo;
+//    // intentional memory leak to make sure our smart pointers don't go out of scope
+//    RegionDemo & regionDemo = * new RegionDemo;
 
-    {
-        // read in a region from a fixed filename
-        QString inputFname = "/scratch/regions.json";
-        qDebug() << "Trying to parse" << inputFname;
-        QFile fp( inputFname );
-        if ( ! fp.open( QIODevice::ReadOnly ) ) {
-            qWarning() << "Could not open " << fp.fileName();
-        }
-        else {
-            QByteArray contents = fp.readAll();
-            QJsonParseError jerr;
-            QJsonDocument jdoc = QJsonDocument::fromJson( contents, & jerr );
-            if ( jerr.error != QJsonParseError::NoError ) {
-                qWarning() << "Json parse error@" << jerr.offset << ":" << jerr.errorString();
-            }
-            else {
-                Carta::Lib::Regions::RegionBase * bb = Carta::Lib::Regions::fromJson( jdoc.object() );
-                regionDemo.regionSet.reset( bb );
-                qDebug() << "Read in region base";
-            }
-        }
-    }
-    regionDemo.regionSetModel =
-        std::make_shared < editable::RegionSetModel > ();
+//    {
+//        // read in a region from a fixed filename
+//        QString inputFname = "/scratch/regions.json";
+//        qDebug() << "Trying to parse" << inputFname;
+//        QFile fp( inputFname );
+//        if ( ! fp.open( QIODevice::ReadOnly ) ) {
+//            qWarning() << "Could not open " << fp.fileName();
+//        }
+//        else {
+//            QByteArray contents = fp.readAll();
+//            QJsonParseError jerr;
+//            QJsonDocument jdoc = QJsonDocument::fromJson( contents, & jerr );
+//            if ( jerr.error != QJsonParseError::NoError ) {
+//                qWarning() << "Json parse error@" << jerr.offset << ":" << jerr.errorString();
+//            }
+//            else {
+//                Carta::Lib::Regions::RegionBase * bb = Carta::Lib::Regions::fromJson( jdoc.object() );
+//                regionDemo.regionSet.reset( bb );
+//                qDebug() << "Read in region base";
+//            }
+//        }
+//    }
+//    regionDemo.regionSetModel =
+//        std::make_shared < editable::RegionSetModel > ();
 
-    editable::RegionEditorLayer * reditorlayer = new editable::RegionEditorLayer( mlvRaw, "regions" );
-    reditorlayer-> setRegionSetModel( regionDemo.regionSetModel );
+//    editable::RegionEditorLayer * reditorlayer = new editable::RegionEditorLayer( mlvRaw, "regions" );
+//    reditorlayer-> setRegionSetModel( regionDemo.regionSetModel );
 
-    // update region set model with our region set
-    regionDemo.regionSetModel-> setRegionSet( regionDemo.regionSet );
-    regionDemo.regionSetModel-> scheduleUpdateSignal();
+//    // update region set model with our region set
+//    regionDemo.regionSetModel-> setRegionSet( regionDemo.regionSet );
+//    regionDemo.regionSetModel-> scheduleUpdateSignal();
 
-    m_pimpl-> mlv-> setInputLayers( { reditorlayer-> layerID() }
-                                    );
+//    m_pimpl-> mlv-> setInputLayers( { reditorlayer-> layerID() }
+//                                    );
 
-    m_pimpl-> lvc.reset( new LayeredViewController( m_pimpl-> mlv.get() ) );
-}
+//    m_pimpl-> lvc.reset( new LayeredViewController( m_pimpl-> mlv.get() ) );
+//}
 
-LayeredViewDemo::~LayeredViewDemo()
-{
-    if ( m_pimpl ) {
-        delete m_pimpl;
-        m_pimpl = nullptr;
-    }
-}
-}
-}
+//LayeredViewDemo::~LayeredViewDemo()
+//{
+//    if ( m_pimpl ) {
+//        delete m_pimpl;
+//        m_pimpl = nullptr;
+//    }
+//}
+//}
+//}
 
 // hack for declaring qobject classes inside .cpp instead of headers. This will force
 // moc to process the .cpp file...

--- a/carta/cpp/core/Hacks/LayeredViewDemo.h
+++ b/carta/cpp/core/Hacks/LayeredViewDemo.h
@@ -9,28 +9,28 @@
 #include "ManagedLayerView.h"
 #include <QObject>
 
-namespace Carta
-{
-namespace Hacks
-{
-class LayeredViewDemo : public QObject
-{
-    Q_OBJECT
-    CLASS_BOILERPLATE( LayeredViewDemo);
+//namespace Carta
+//{
+//namespace Hacks
+//{
+//class LayeredViewDemo : public QObject
+//{
+//    Q_OBJECT
+//    CLASS_BOILERPLATE( LayeredViewDemo);
 
-public:
-    explicit LayeredViewDemo(QObject *parent = 0);
-    ~LayeredViewDemo();
+//public:
+//    explicit LayeredViewDemo(QObject *parent = 0);
+//    ~LayeredViewDemo();
 
-signals:
+//signals:
 
-public slots:
+//public slots:
 
-private:
-    struct Pimpl;
-    Pimpl * m_pimpl = nullptr;
+//private:
+//    struct Pimpl;
+//    Pimpl * m_pimpl = nullptr;
 
-};
+//};
 
-}
-}
+//}
+//}

--- a/carta/cpp/core/Hacks/ManagedLayerView.cpp
+++ b/carta/cpp/core/Hacks/ManagedLayerView.cpp
@@ -15,23 +15,23 @@ ManagedLayerBase::ManagedLayerBase( ManagedLayerView * mlv, QString name )
     m_id = m_mlv-> p_addLayer( this );
 }
 
-void
-ManagedLayerBase::setRaster( const QImage & image )
-{
-    m_vgListBuff = Carta::Lib::VectorGraphics::VGList();
-    m_rasterBuff = image;
-    m_isRaster = true;
-    m_mlv-> scheduleRepaint();
-}
+//void
+//ManagedLayerBase::setRaster( const QImage & image )
+//{
+//    m_vgListBuff = Carta::Lib::VectorGraphics::VGList();
+//    m_rasterBuff = image;
+//    m_isRaster = true;
+//    m_mlv-> scheduleRepaint();
+//}
 
-void
-ManagedLayerBase::setVG( const Lib::VectorGraphics::VGList & vgList )
-{
-    m_rasterBuff = QImage();
-    m_vgListBuff = vgList;
-    m_isRaster = false;
-    m_mlv-> scheduleRepaint();
-}
+//void
+//ManagedLayerBase::setVG( const Lib::VectorGraphics::VGList & vgList )
+//{
+//    m_rasterBuff = QImage();
+//    m_vgListBuff = vgList;
+//    m_isRaster = false;
+//    m_mlv-> scheduleRepaint();
+//}
 
 ManagedLayerView::ManagedLayerView( QString viewName,
                                     IConnector * connector,
@@ -45,17 +45,17 @@ ManagedLayerView::ManagedLayerView( QString viewName,
     m_lrv.reset( new Carta::Lib::LayeredViewArbitrary( m_connector, viewName, this ) );
 
     // listen for resize events
-    connect( m_lrv.get(), & Carta::Lib::LayeredViewArbitrary::sizeChanged,
-             this, & Me::clientSizeChangedCB );
+//    connect( m_lrv.get(), & Carta::Lib::LayeredViewArbitrary::sizeChanged,
+//             this, & Me::clientSizeChangedCB );
 
-    // listen for input events
-    connect( m_lrv.get(), & Carta::Lib::LayeredViewArbitrary::inputEvent,
-             this, & Me::inputEventCB );
+//    // listen for input events
+//    connect( m_lrv.get(), & Carta::Lib::LayeredViewArbitrary::inputEvent,
+//             this, & Me::inputEventCB );
 
     // connect the repaint timer
     m_repaintTimer.setInterval( 0 );
     m_repaintTimer.setSingleShot( true );
-    connect( & m_repaintTimer, & QTimer::timeout, this, & Me::repaintTimerCB );
+//    connect( & m_repaintTimer, & QTimer::timeout, this, & Me::repaintTimerCB );
 }
 
 void
@@ -194,37 +194,37 @@ ManagedLayerView::scheduleRepaint()
     return m_repaintId;
 } // scheduleRepaint
 
-void
-ManagedLayerView::clientSizeChangedCB()
-{
-    // tell all layers about the size changes
-    auto clientSize = m_lrv-> getClientSize();
-    for ( auto * layer : m_layers ) {
-        layer-> onResize( clientSize );
-    }
-}
-
-void
-ManagedLayerView::inputEventCB( Lib::InputEvent e )
-{
-    qDebug() << "Received input event" << e.json()["type"].toString();
-
-    // now go through our list of input layers and invoke their input event callbacks
-    for ( auto layer : m_layers ) {
-        if ( layer-> hasInput() ) {
-            layer-> onInputEvent( e );
-
-            // abort once the event is consumed
-            if ( e.isConsumed() ) {
-                break;
-            }
-        }
-    }
-
-//    if( CARTA_RUNTIME_CHECKS && ! e.isConsumed()) {
-//        qWarning() << "Unconsumed event" << e.type();
+//void
+//ManagedLayerView::clientSizeChangedCB()
+//{
+//    // tell all layers about the size changes
+//    auto clientSize = m_lrv-> getClientSize();
+//    for ( auto * layer : m_layers ) {
+//        layer-> onResize( clientSize );
 //    }
-} // inputEventCB
+//}
+
+//void
+//ManagedLayerView::inputEventCB( Lib::InputEvent e )
+//{
+//    qDebug() << "Received input event" << e.json()["type"].toString();
+
+//    // now go through our list of input layers and invoke their input event callbacks
+//    for ( auto layer : m_layers ) {
+//        if ( layer-> hasInput() ) {
+//            layer-> onInputEvent( e );
+
+//            // abort once the event is consumed
+//            if ( e.isConsumed() ) {
+//                break;
+//            }
+//        }
+//    }
+
+////    if( CARTA_RUNTIME_CHECKS && ! e.isConsumed()) {
+////        qWarning() << "Unconsumed event" << e.type();
+////    }
+//} // inputEventCB
 
 /*
 void
@@ -252,34 +252,34 @@ ManagedLayerView::repaintTimerCB()
     m_lrv-> scheduleRepaint( m_repaintId );
 } // inputEventCB
 */
-void
-ManagedLayerView::repaintTimerCB()
-{
-    m_lrv-> removeAllLayers();
-    int layerInd = 0;
+//void
+//ManagedLayerView::repaintTimerCB()
+//{
+//    m_lrv-> removeAllLayers();
+//    int layerInd = 0;
 
-//    int vgInd = 0;
-    for ( auto * l : m_layers ) {
-        if ( l-> isRaster() ) {
-            m_lrv-> setLayerRaster( layerInd, l-> raster() );
-            m_lrv-> setLayerCombiner( layerInd, l-> rasterCombiner() );
-        }
-        else {
-            m_lrv-> setLayerVG( layerInd, l-> vgList() );
-        }
-        layerInd++;
-    }
-
+////    int vgInd = 0;
 //    for ( auto * l : m_layers ) {
 //        if ( l-> isRaster() ) {
-//            continue;
+//            m_lrv-> setLayerRaster( layerInd, l-> raster() );
+//            m_lrv-> setLayerCombiner( layerInd, l-> rasterCombiner() );
 //        }
-//        m_lrv-> setVGLayer( vgInd, l-> vgList() );
-//        vgInd++;
+//        else {
+//            m_lrv-> setLayerVG( layerInd, l-> vgList() );
+//        }
+//        layerInd++;
 //    }
 
-    m_lrv-> scheduleRepaint( m_repaintId );
-} // inputEventCB
+////    for ( auto * l : m_layers ) {
+////        if ( l-> isRaster() ) {
+////            continue;
+////        }
+////        m_lrv-> setVGLayer( vgInd, l-> vgList() );
+////        vgInd++;
+////    }
+
+//    m_lrv-> scheduleRepaint( m_repaintId );
+//} // inputEventCB
 
 ManagedLayerBase::ID
 ManagedLayerView::p_addLayer( ManagedLayerBase * layer )

--- a/carta/cpp/core/Hacks/ManagedLayerView.h
+++ b/carta/cpp/core/Hacks/ManagedLayerView.h
@@ -53,12 +53,12 @@ public:
     onInputEvent( Carta::Lib::InputEvent & event ) { Q_UNUSED( event ); }
 
     /// call this to update the rendering of raster
-    void
-    setRaster( const QImage & image );
+//    void
+//    setRaster( const QImage & image );
 
     /// call this to update the rendering vector graphics
-    void
-    setVG( const Carta::Lib::VectorGraphics::VGList & vgList );
+//    void
+//    setVG( const Carta::Lib::VectorGraphics::VGList & vgList );
 
     /// does the layer have input?
     bool
@@ -90,18 +90,18 @@ private:
     isRaster() { return m_isRaster; }
 
     bool m_isRaster = true;
-    QImage m_rasterBuff;
+//    QImage m_rasterBuff;
     Carta::Lib::IQImageCombiner::SharedPtr m_rasterCombiner;
-    Carta::Lib::VectorGraphics::VGList m_vgListBuff;
+//    Carta::Lib::VectorGraphics::VGList m_vgListBuff;
 
     Carta::Lib::IQImageCombiner::SharedPtr
     rasterCombiner() { return m_rasterCombiner; }
 
-    const QImage &
-    raster() { return m_rasterBuff; }
+//    const QImage &
+//    raster() { return m_rasterBuff; }
 
-    const Carta::Lib::VectorGraphics::VGList &
-    vgList() { return m_vgListBuff; }
+//    const Carta::Lib::VectorGraphics::VGList &
+//    vgList() { return m_vgListBuff; }
 
     /// does the layer receive input?
     bool m_hasInput = false;
@@ -169,16 +169,16 @@ public slots:
 private slots:
 
     // callback for client size changes from LayeredRemoteVGView
-    void
-    clientSizeChangedCB();
+//    void
+//    clientSizeChangedCB();
 
-    // callback for input events
-    void
-    inputEventCB( Carta::Lib::InputEvent e );
+//    // callback for input events
+//    void
+//    inputEventCB( Carta::Lib::InputEvent e );
 
     // internal repaint timer callback
-    void
-    repaintTimerCB();
+//    void
+//    repaintTimerCB();
 
 private:
 

--- a/carta/cpp/core/IConnector.h
+++ b/carta/cpp/core/IConnector.h
@@ -2,13 +2,14 @@
 #define ICONNECTOR_H
 
 #include "IView.h"
+#include "IPlatform.h"
 
 #include <memory>
 #include <functional>
 #include <cstdint>
 #include <QString>
-#include <QMouseEvent>
-#include <QKeyEvent>
+//#include <QMouseEvent>
+//#include <QKeyEvent>
 #include <google/protobuf/message_lite.h>
 
 namespace Carta {

--- a/carta/cpp/core/IView.h
+++ b/carta/cpp/core/IView.h
@@ -5,9 +5,9 @@
 #pragma once
 
 class IConnector;
-class QImage;
-class QMouseEvent;
-class QKeyEvent;
+//class QImage;
+//class QMouseEvent;
+//class QKeyEvent;
 class QString;
 class QSize;
 
@@ -59,8 +59,8 @@ public:
     /// \note strongly suggested format: QImage::Format_ARGB32_Premultiplied, as that is
     /// the most optimized version
     ///
-    virtual const QImage &
-    getBuffer() = 0;
+//    virtual const QImage &
+//    getBuffer() = 0;
 
     /// handle client resize request
     virtual void
@@ -68,13 +68,13 @@ public:
 
     /// handle mouse events
     /// \deprecated this is going away in the future, or at least will become optional
-    virtual void
-    handleMouseEvent( const QMouseEvent & event ) = 0;
+//    virtual void
+//    handleMouseEvent( const QMouseEvent & event ) = 0;
 
     /// handle keyboard events
     /// \deprecated this may be removed altogether, or become optional
-    virtual void
-    handleKeyEvent( const QKeyEvent & event ) = 0;
+//    virtual void
+//    handleKeyEvent( const QKeyEvent & event ) = 0;
 
     /// this is called when a view is refreshed in the GUI
     virtual void viewRefreshed( qint64 id) = 0;

--- a/carta/cpp/core/ImageView.cpp
+++ b/carta/cpp/core/ImageView.cpp
@@ -8,7 +8,7 @@
 
 #include <iostream>
 
-#include <QPainter>
+//#include <QPainter>
 #include <cmath>
 #include <QDebug>
 #include <QCoreApplication>
@@ -18,21 +18,21 @@ const QString ImageView::VIEW = "view";
 const QString ImageView::MOUSE_Y = "mouse/x";
 const QString ImageView::MOUSE_X = "mouse/y";
 
-ImageView::ImageView(const QString & viewName, QColor bgColor, QImage img,
-        Carta::State::StateInterface* mouseState){
-    m_defaultImage = img;
-    m_qimage = QImage(100, 100, QImage::Format_ARGB32_Premultiplied);
-    m_qimage.fill(bgColor);
+//ImageView::ImageView(const QString & viewName, QColor bgColor, QImage img,
+//        Carta::State::StateInterface* mouseState){
+//    m_defaultImage = img;
+//    m_qimage = QImage(100, 100, QImage::Format_ARGB32_Premultiplied);
+//    m_qimage.fill(bgColor);
 
-    m_viewName = Carta::State::UtilState::getLookup( viewName, VIEW);
-    m_connector = nullptr;
-    m_bgColor = bgColor;
-    m_mouseState = mouseState;
-}
+//    m_viewName = Carta::State::UtilState::getLookup( viewName, VIEW);
+//    m_connector = nullptr;
+//    m_bgColor = bgColor;
+//    m_mouseState = mouseState;
+//}
 
-void ImageView::resetImage(QImage img) {
-     m_defaultImage = img;
-}
+//void ImageView::resetImage(QImage img) {
+//     m_defaultImage = img;
+//}
 
 void ImageView::registration(IConnector *connector) {
     m_connector = connector;
@@ -42,47 +42,47 @@ const QString & ImageView::name() const {
     return m_viewName;
 }
 
-QSize ImageView::size() {
-    return m_qimage.size();
-}
+//QSize ImageView::size() {
+//    return m_qimage.size();
+//}
 
-const QImage & ImageView::getBuffer() {
-    redrawBuffer();
-    return m_qimage;
-}
+//const QImage & ImageView::getBuffer() {
+//    redrawBuffer();
+//    return m_qimage;
+//}
 
-void ImageView::handleResizeRequest(const QSize & size) {
-    if ( size.height() > 0 && size.width() > 0 ){
-        m_qimage = QImage(size, m_qimage.format());
-        emit resize( size );
-    }
-}
+//void ImageView::handleResizeRequest(const QSize & size) {
+//    if ( size.height() > 0 && size.width() > 0 ){
+//        m_qimage = QImage(size, m_qimage.format());
+//        emit resize( size );
+//    }
+//}
 
-void ImageView::handleMouseEvent(const QMouseEvent & ev) {
-    m_lastMouse = QPointF(ev.x(), ev.y());
-    m_mouseState->setValue<QString>( MOUSE_X, QString::number(ev.x()));
-    m_mouseState->setValue<QString>( MOUSE_Y, QString::number(ev.y()));
-    m_mouseState->flushState();
-}
+//void ImageView::handleMouseEvent(const QMouseEvent & ev) {
+//    m_lastMouse = QPointF(ev.x(), ev.y());
+//    m_mouseState->setValue<QString>( MOUSE_X, QString::number(ev.x()));
+//    m_mouseState->setValue<QString>( MOUSE_Y, QString::number(ev.y()));
+//    m_mouseState->flushState();
+//}
 
 
-void ImageView::scheduleRedraw(){
-    redrawBuffer();
-    m_connector-> refreshView( this );
-}
+//void ImageView::scheduleRedraw(){
+//    redrawBuffer();
+//    m_connector-> refreshView( this );
+//}
 
-void ImageView::redrawBuffer() {
-    if ( !m_qimage.isNull() ){
-        m_qimage.fill( "#E0E0E0" );
-        {
-            QPainter p(&m_qimage);
-            p.drawImage(m_qimage.rect(), m_defaultImage);
-        }
+//void ImageView::redrawBuffer() {
+//    if ( !m_qimage.isNull() ){
+//        m_qimage.fill( "#E0E0E0" );
+//        {
+//            QPainter p(&m_qimage);
+//            p.drawImage(m_qimage.rect(), m_defaultImage);
+//        }
 
-        // execute the pre-render hook
-        Globals::instance()->pluginManager()->prepare<PreRender>(m_viewName,
-                &m_qimage).executeAll();
-    }
-}
+//        // execute the pre-render hook
+//        Globals::instance()->pluginManager()->prepare<PreRender>(m_viewName,
+//                &m_qimage).executeAll();
+//    }
+//}
 
 

--- a/carta/cpp/core/ImageView.h
+++ b/carta/cpp/core/ImageView.h
@@ -1,6 +1,7 @@
 #include "IView.h"
-#include <QImage>
-#include <QColor>
+//#include <QImage>
+//#include <QColor>
+#include <QObject>
 
 class IConnector;
 
@@ -16,20 +17,20 @@ Q_OBJECT
 
 public:
 
-    ImageView(const QString & viewName, QColor bgColor, QImage img, Carta::State::StateInterface* mouseState);
+//    ImageView(const QString & viewName, QColor bgColor, QImage img, Carta::State::StateInterface* mouseState);
 
-    void resetImage(QImage img);
+//    void resetImage(QImage img);
     /**
      * Refresh the view.
      */
-    void scheduleRedraw();
+//    void scheduleRedraw();
     virtual void registration(IConnector *connector) override;
     virtual const QString & name() const override;
-    virtual QSize size() override;
-    virtual const QImage & getBuffer() override;
-    virtual void handleResizeRequest(const QSize & size) override;
-    virtual void handleMouseEvent(const QMouseEvent & ev) override;
-    virtual void handleKeyEvent(const QKeyEvent & /*event*/) override {}
+//    virtual QSize size() override;
+//    virtual const QImage & getBuffer() override;
+//    virtual void handleResizeRequest(const QSize & size) override;
+//    virtual void handleMouseEvent(const QMouseEvent & ev) override;
+//    virtual void handleKeyEvent(const QKeyEvent & /*event*/) override {}
     virtual void viewRefreshed( qint64 /*id*/) override {}
     static const QString MOUSE;
     static const QString MOUSE_X;
@@ -42,15 +43,15 @@ signals:
 
 protected:
 
-    void redrawBuffer();
+//    void redrawBuffer();
 
-    QColor m_bgColor;
-    QImage m_defaultImage;
+//    QColor m_bgColor;
+//    QImage m_defaultImage;
     IConnector * m_connector;
-    QImage m_qimage;
+//    QImage m_qimage;
     QString m_viewName;
     int m_timerId;
-    QPointF m_lastMouse;
+//    QPointF m_lastMouse;
     Carta::State::StateInterface* m_mouseState;
 
 

--- a/carta/cpp/core/MyQApp.cpp
+++ b/carta/cpp/core/MyQApp.cpp
@@ -10,7 +10,7 @@
 #include <QDebug>
 
 MyQApp::MyQApp( int & argc, char * * argv ) :
-    QApplication( argc, argv )
+    QCoreApplication( argc, argv )
 {
     setApplicationName( "carta" );
     setApplicationVersion( "0.9" );
@@ -23,7 +23,7 @@ MyQApp::notify( QObject * obj, QEvent * ev )
 {
     QStringList err;
     try {
-        return QApplication::notify( obj, ev );
+        return QCoreApplication::notify( obj, ev );
     }
     catch ( std::exception & e ) {
         err << QString( "Exception (std::exception): %1" ).arg( e.what() );

--- a/carta/cpp/core/MyQApp.h
+++ b/carta/cpp/core/MyQApp.h
@@ -2,14 +2,14 @@
 
 /// \todo move this all into carta::core namespace
 
-#include <QApplication>
+#include <QCoreApplication>
 #include <functional>
 
 /// The only code that should go into this class is Qt specific stuff that needs
 /// access to the internals of QApplication.
 ///
 /// @todo For server side this should be QGuiApplication
-class MyQApp : public QApplication
+class MyQApp : public QCoreApplication
 {
     Q_OBJECT
 

--- a/carta/cpp/core/PluginManager.cpp
+++ b/carta/cpp/core/PluginManager.cpp
@@ -11,7 +11,7 @@
 #include "Globals.h"
 #include "MainConfig.h"
 #include <QDirIterator>
-#include <QImage>
+//#include <QImage>
 #include <QPluginLoader>
 #include <QLibrary>
 #include <QtGlobal>

--- a/carta/cpp/core/PluginManager.h
+++ b/carta/cpp/core/PluginManager.h
@@ -7,7 +7,7 @@
 #include "CartaLib/IPlugin.h"
 #include "CartaLib/Nullable.h"
 
-#include <QImage>
+//#include <QImage>
 #include <QString>
 #include <vector>
 #include <functional>

--- a/carta/cpp/core/ScriptedClient/ScriptFacade.cpp
+++ b/carta/cpp/core/ScriptedClient/ScriptFacade.cpp
@@ -455,7 +455,7 @@ QStringList ScriptFacade::setImage( const QString& animatorId, int index ) {
     if ( obj != nullptr ){
         Carta::Data::Animator* animator = dynamic_cast<Carta::Data::Animator*>(obj);
         if ( animator != nullptr){
-            animator->changeFrame( index, Carta::Data::Selection::IMAGE );
+//            animator->changeFrame( index, Carta::Data::Selection::IMAGE );
         }
         else {
             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
@@ -824,14 +824,14 @@ QStringList ScriptFacade::getOutputSize( const QString& controlId ) {
     if ( obj != nullptr ){
         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
         if ( controller != nullptr ){
-            QSize size = controller->getOutputSize( );
-            if ( size.isEmpty() ) {
-                resultList = _logErrorMessage( ERROR, "Could not obtain output size." );
-            }
-            else {
-                resultList.append( QString::number( size.width() ));
-                resultList.append( QString::number( size.height() ));
-            }
+//            QSize size = controller->getOutputSize( );
+//            if ( size.isEmpty() ) {
+//                resultList = _logErrorMessage( ERROR, "Could not obtain output size." );
+//            }
+//            else {
+//                resultList.append( QString::number( size.width() ));
+//                resultList.append( QString::number( size.height() ));
+//            }
         }
         else {
             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );

--- a/carta/cpp/core/SimpleRemoteVGView.cpp
+++ b/carta/cpp/core/SimpleRemoteVGView.cpp
@@ -11,11 +11,11 @@ namespace Carta
 {
 namespace Core
 {
-const QSize &
-SimpleRemoteVGView::getClientSize()
-{
-    return m_remoteSize;
-}
+//const QSize &
+//SimpleRemoteVGView::getClientSize()
+//{
+//    return m_remoteSize;
+//}
 
 const QString &
 SimpleRemoteVGView::getRVGViewName()
@@ -30,24 +30,24 @@ SimpleRemoteVGView::getRVGViewName()
 //    m_bgColor = color;
 //}
 
-void
-SimpleRemoteVGView::setRaster( const QImage & image )
-{
-    m_raster = image;
-}
+//void
+//SimpleRemoteVGView::setRaster( const QImage & image )
+//{
+//    m_raster = image;
+//}
 
-void
-SimpleRemoteVGView::setVG( const Lib::IRemoteVGView::VGList & vglist )
-{
-    m_vgList = vglist;
-}
+//void
+//SimpleRemoteVGView::setVG( const Lib::IRemoteVGView::VGList & vglist )
+//{
+//    m_vgList = vglist;
+//}
 
-void
-SimpleRemoteVGView::setRasterAndVG( const QImage & image, const Lib::IRemoteVGView::VGList & vglist )
-{
-    setRaster( image );
-    setVG( vglist );
-}
+//void
+//SimpleRemoteVGView::setRasterAndVG( const QImage & image, const Lib::IRemoteVGView::VGList & vglist )
+//{
+//    setRaster( image );
+//    setVG( vglist );
+//}
 
 void
 SimpleRemoteVGView::setVGrenderedOnServer( bool flag )
@@ -64,24 +64,24 @@ SimpleRemoteVGView::isVGrenderedOnServer()
     return true;
 }
 
-qint64
-SimpleRemoteVGView::scheduleRepaint( qint64 id )
-{
-    // indicate m_buffer needs to be repainted
-    m_buffer = QImage();
+//qint64
+//SimpleRemoteVGView::scheduleRepaint( qint64 id )
+//{
+//    // indicate m_buffer needs to be repainted
+//    m_buffer = QImage();
 
-    // remember the ID of the job
-    if ( id == - 1 ) {
-        id = m_lastRepaintId + 1;
-    }
-    m_lastRepaintId = id;
+//    // remember the ID of the job
+//    if ( id == - 1 ) {
+//        id = m_lastRepaintId + 1;
+//    }
+//    m_lastRepaintId = id;
 
-    // ask the connector for a repaint
-    m_connector-> refreshView( this );
+//    // ask the connector for a repaint
+//    m_connector-> refreshView( this );
 
-    // return the id
-    return id;
-}
+//    // return the id
+//    return id;
+//}
 
 SimpleRemoteVGView::SimpleRemoteVGView( QObject * parent,
                                         QString viewName,
@@ -91,16 +91,16 @@ SimpleRemoteVGView::SimpleRemoteVGView( QObject * parent,
     m_viewName = viewName;
     m_connector = connector;
 
-    m_raster = QImage( 100, 100, QImage::Format_ARGB32_Premultiplied );
-    m_raster.fill( 0xff000000 );
+//    m_raster = QImage( 100, 100, QImage::Format_ARGB32_Premultiplied );
+//    m_raster.fill( 0xff000000 );
 
     m_connector-> registerView( this );
 
     using namespace std::placeholders;
 
-    m_connector->addCommandCallback(
-        QString( "vgview/inputEvent/%1" ).arg( viewName ),
-        std::bind( & Me::inputEventCB, this, _1, _2, _3 ) );
+//    m_connector->addCommandCallback(
+//        QString( "vgview/inputEvent/%1" ).arg( viewName ),
+//        std::bind( & Me::inputEventCB, this, _1, _2, _3 ) );
 }
 
 void
@@ -117,42 +117,42 @@ SimpleRemoteVGView::name() const
     return m_viewName;
 }
 
-QSize
-SimpleRemoteVGView::size()
-{
-    if ( m_buffer.isNull() ) {
-        m_buffer = m_raster;
-        QPainter painter( & m_buffer );
-        if ( painter.isActive() ){
-			Carta::Lib::VectorGraphics::VGListQPainterRenderer renderer;
-			renderer.render( m_vgList, painter );
-			painter.end();
-        }
-    }
-    return m_buffer.size();
-}
+//QSize
+//SimpleRemoteVGView::size()
+//{
+//    if ( m_buffer.isNull() ) {
+//        m_buffer = m_raster;
+//        QPainter painter( & m_buffer );
+//        if ( painter.isActive() ){
+//			Carta::Lib::VectorGraphics::VGListQPainterRenderer renderer;
+//			renderer.render( m_vgList, painter );
+//			painter.end();
+//        }
+//    }
+//    return m_buffer.size();
+//}
 
-const QImage &
-SimpleRemoteVGView::getBuffer()
-{
-    (void) size();
-    return m_buffer;
-}
+//const QImage &
+//SimpleRemoteVGView::getBuffer()
+//{
+//    (void) size();
+//    return m_buffer;
+//}
 
-void
-SimpleRemoteVGView::handleResizeRequest( const QSize & size )
-{
-    m_remoteSize = size;
-    emit sizeChanged();
-}
+//void
+//SimpleRemoteVGView::handleResizeRequest( const QSize & size )
+//{
+//    m_remoteSize = size;
+//    emit sizeChanged();
+//}
 
-void
-SimpleRemoteVGView::handleMouseEvent( const QMouseEvent & /*event*/ )
-{ }
+//void
+//SimpleRemoteVGView::handleMouseEvent( const QMouseEvent & /*event*/ )
+//{ }
 
-void
-SimpleRemoteVGView::handleKeyEvent( const QKeyEvent & /*event*/ )
-{ }
+//void
+//SimpleRemoteVGView::handleKeyEvent( const QKeyEvent & /*event*/ )
+//{ }
 
 void
 SimpleRemoteVGView::viewRefreshed( qint64 id )
@@ -160,18 +160,19 @@ SimpleRemoteVGView::viewRefreshed( qint64 id )
     Q_UNUSED( id );
 }
 
-QString
-SimpleRemoteVGView::inputEventCB( const QString & cmd,
-                                  const QString & params,
-                                  const QString & sessionId )
-{
-    Q_UNUSED( cmd );
-    Q_UNUSED( sessionId );
-    qDebug() << "Input event[" << this->m_viewName << "]:" << params;
+//QString
+//SimpleRemoteVGView::inputEventCB( const QString & cmd,
+//                                  const QString & params,
+//                                  const QString & sessionId )
+//{
+//    Q_UNUSED( cmd );
+//    Q_UNUSED( sessionId );
+//    qDebug() << "Input event[" << this->m_viewName << "]:" << params;
 
-//    emit inputEvent( Carta::Lib::InputEvent( Carta::Lib::InputEvent::Type::Custom, "tap"));
-    emit inputEvent( Carta::Lib::InputEvent( QJsonDocument::fromJson( params.toLatin1() ).object() ) );
-    return QString();
-}
+////    emit inputEvent( Carta::Lib::InputEvent( Carta::Lib::InputEvent::Type::Custom, "tap"));
+//    emit inputEvent( Carta::Lib::InputEvent( QJsonDocument::fromJson( params.toLatin1() ).object() ) );
+//    return QString();
+//}
+
 }
 }

--- a/carta/cpp/core/SimpleRemoteVGView.h
+++ b/carta/cpp/core/SimpleRemoteVGView.h
@@ -9,8 +9,8 @@
 #include "IView.h"
 #include <QSize>
 #include <QString>
-#include <QColor>
-#include <QImage>
+//#include <QColor>
+//#include <QImage>
 
 class ServerConnector;
 class NewServerConnector;
@@ -33,20 +33,20 @@ class SimpleRemoteVGView
 
 public:
 
-    virtual const QSize &
-    getClientSize() override;
+//    virtual const QSize &
+//    getClientSize() override;
 
     virtual const QString &
     getRVGViewName() override;
 
-    virtual void
-    setRaster( const QImage & image ) override;
+//    virtual void
+//    setRaster( const QImage & image ) override;
 
-    virtual void
-    setVG( const VGList & vglist ) override;
+//    virtual void
+//    setVG( const VGList & vglist ) override;
 
-    virtual void
-    setRasterAndVG( const QImage & image, const VGList & vglist ) override;
+//    virtual void
+//    setRasterAndVG( const QImage & image, const VGList & vglist ) override;
 
     virtual void
     setVGrenderedOnServer( bool flag) override;
@@ -59,8 +59,8 @@ public:
 
 public slots:
 
-    virtual qint64
-    scheduleRepaint( qint64 id = - 1 ) override;
+//    virtual qint64
+//    scheduleRepaint( qint64 id = - 1 ) override;
 
 private:
 
@@ -72,10 +72,10 @@ private:
     QSize m_remoteSize = QSize( 1, 1 );
     QString m_viewName;
     IConnector * m_connector = nullptr;
-    QImage m_raster, m_buffer;
+//    QImage m_raster, m_buffer;
 
-    VGList m_vgList;
-    qint64 m_lastRepaintId = - 1;
+//    VGList m_vgList;
+//    qint64 m_lastRepaintId = - 1;
 
     // IView interface
 
@@ -85,26 +85,26 @@ private:
     virtual const QString &
     name() const override;
 
-    virtual QSize
-    size() override;
+//    virtual QSize
+//    size() override;
 
-    virtual const QImage &
-    getBuffer() override;
+//    virtual const QImage &
+//    getBuffer() override;
 
-    virtual void
-    handleResizeRequest( const QSize & size ) override;
+//    virtual void
+//    handleResizeRequest( const QSize & size ) override;
 
-    virtual void
-    handleMouseEvent( const QMouseEvent & event ) override;
+//    virtual void
+//    handleMouseEvent( const QMouseEvent & event ) override;
 
-    virtual void
-    handleKeyEvent( const QKeyEvent & event ) override;
+//    virtual void
+//    handleKeyEvent( const QKeyEvent & event ) override;
 
     virtual void
     viewRefreshed( qint64 id) override ;
 
     // for now this is how we handle input events... same for desktop and server
-    QString inputEventCB( const QString & cmd, const QString & params, const QString & sessionId);
+//    QString inputEventCB( const QString & cmd, const QString & params, const QString & sessionId);
 
 };
 }

--- a/carta/cpp/core/core.pro
+++ b/carta/cpp/core/core.pro
@@ -5,7 +5,7 @@
 TEMPLATE = lib
 
 ###CONFIG += staticlib
-QT += widgets network
+QT += network
 QT += xml
 QT += concurrent
 

--- a/carta/cpp/core/coreMain.h
+++ b/carta/cpp/core/coreMain.h
@@ -6,7 +6,7 @@
 
 #include "core/Viewer.h"
 #include "PluginManager.h"
-#include "core/Hacks/HackViewer.h"
+//#include "core/Hacks/HackViewer.h"
 #include "core/MyQApp.h"
 #include "core/CmdLine.h"
 #include "core/MainConfig.h"
@@ -145,14 +145,14 @@ coreMainCPP( QString platformString, int argc, char * * argv )
 
     // create the viewer
     // =================
-    Viewer viewer;
-    Hacks::HackViewer::UniquePtr hackViewer = nullptr;
-    if ( globals.mainConfig()-> hacksEnabled() ) {
-        hackViewer.reset( new Hacks::HackViewer );
-    }
-    if ( globals.mainConfig()->isDeveloperLayout() ) {
-        viewer.setDeveloperView();
-    }
+//    Viewer viewer;
+//    Hacks::HackViewer::UniquePtr hackViewer = nullptr;
+//    if ( globals.mainConfig()-> hacksEnabled() ) {
+//        hackViewer.reset( new Hacks::HackViewer );
+//    }
+//    if ( globals.mainConfig()->isDeveloperLayout() ) {
+//        viewer.setDeveloperView();
+//    }
 
     // prepare closure to execute when connector is initialized
 //    IConnector::InitializeCallback initCB = [&] ( const QString &sessionID) -> void {

--- a/carta/cpp/cpp.pro
+++ b/carta/cpp/cpp.pro
@@ -9,9 +9,9 @@ SUBDIRS = \
     desktop \
     plugins \
     Tests \
-    testCache \
-    testRegion \
-    testPercentile
+#    testCache \
+#    testRegion \
+#    testPercentile
 
 # explicit dependencies, to make sure parallel make works (i.e. make -j4...)
 core.depends = CartaLib

--- a/carta/cpp/desktop/DesktopPlatform.cpp
+++ b/carta/cpp/desktop/DesktopPlatform.cpp
@@ -4,13 +4,9 @@
 
 #include "DesktopPlatform.h"
 #include "SessionDispatcher.h"
-// #include "MainWindow.h"
 #include "core/CmdLine.h"
 #include "core/Globals.h"
 
-#include <QtWidgets>
-//#include <QWebSettings>
-#include <QDesktopWidget>
 #include <unistd.h>
 
 std::string warningColor, criticalColor, fatalColor, resetColor;

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -147,7 +147,7 @@ IConnector::CallbackID NewServerConnector::addStateCallback(
 void NewServerConnector::registerView(IView * view)
 {
     // let the view know it's registered, and give it access to the connector
-    view->registration( this);
+//    view->registration( this);
 
     // insert this view int our list of views
     ViewInfo * viewInfo = new ViewInfo( view);
@@ -209,7 +209,8 @@ void NewServerConnector::removeStateCallback(const IConnector::CallbackID & /*id
 
 Carta::Lib::IRemoteVGView * NewServerConnector::makeRemoteVGView(QString viewName)
 {
-    return new Carta::Core::SimpleRemoteVGView( this, viewName, this);
+//    return new Carta::Core::SimpleRemoteVGView( this, viewName, this);
+    return nullptr;
 }
 
 NewServerConnector::ViewInfo * NewServerConnector::findViewInfo( const QString & viewName)

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -5,8 +5,6 @@
 #include "NewServerConnector.h"
 
 #include <iostream>
-#include <QImage>
-#include <QPainter>
 #include <QXmlInputSource>
 #include <cmath>
 #include <QTime>

--- a/carta/cpp/desktop/NewServerConnector.h
+++ b/carta/cpp/desktop/NewServerConnector.h
@@ -63,8 +63,7 @@ public:
     void unregisterView( const QString& viewName ) override;
     virtual qint64 refreshView( IView * view) override;
     virtual void removeStateCallback( const CallbackID & id) override;
-    virtual Carta::Lib::IRemoteVGView *
-    makeRemoteVGView( QString viewName) override;
+    virtual Carta::Lib::IRemoteVGView * makeRemoteVGView( QString viewName) override;
 
     /// Return the location where the state is saved.
     virtual QString getStateLocation( const QString& saveName ) const override;

--- a/carta/cpp/desktop/SessionDispatcher.cpp
+++ b/carta/cpp/desktop/SessionDispatcher.cpp
@@ -7,8 +7,6 @@
 #include "core/MyQApp.h"
 #include "core/SimpleRemoteVGView.h"
 #include <iostream>
-#include <QImage>
-#include <QPainter>
 #include <QXmlInputSource>
 #include <cmath>
 #include <QTime>

--- a/carta/cpp/desktop/desktop.pro
+++ b/carta/cpp/desktop/desktop.pro
@@ -2,8 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT      +=  network widgets xml websockets webchannel
-# QT      +=  webkitwidgets
+QT      +=  core xml
 
 HEADERS += \
     DesktopPlatform.h \
@@ -30,7 +29,7 @@ INCLUDEPATH += /usr/local/opt/libuv/include
 LIBS += -L/usr/local/opt/libuv/lib -luv
 
 INCLUDEPATH += ../../../ThirdParty/uWebSockets/include
-LIBS += -L../../../ThirdParty/uWebSockets/lib -luWS -lz
+LIBS += -L../../../ThirdParty/uWebSockets/lib -luWS -lz -lssl
 
 unix: LIBS += -L$$OUT_PWD/../core/ -lcore
 unix: LIBS += -L$$OUT_PWD/../CartaLib/ -lCartaLib
@@ -39,15 +38,10 @@ DEPENDPATH += $$PROJECT_ROOT/CartaLib
 
 QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../CartaLib:\$$ORIGIN/../core\''
 
-#QWT_ROOT = $$absolute_path("../../../ThirdParty/qwt")
 unix:macx {
-#    QMAKE_LFLAGS += '-F$$QWT_ROOT/lib'
-#    LIBS +=-framework qwt
     PRE_TARGETDEPS += $$OUT_PWD/../core/libcore.dylib
 }
 else{
-#    QMAKE_LFLAGS += '-Wl,-rpath,\'$$QWT_ROOT/lib\''
-#    LIBS +=-L$$QWT_ROOT/lib -lqwt
     PRE_TARGETDEPS += $$OUT_PWD/../core/libcore.so
 }
 

--- a/carta/cpp/desktop/desktop.pro
+++ b/carta/cpp/desktop/desktop.pro
@@ -2,7 +2,8 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT      +=  core xml
+QT  +=  core xml
+QT  -=  gui widgets
 
 HEADERS += \
     DesktopPlatform.h \

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
@@ -6,7 +6,6 @@
 #include <casacore/coordinates/Coordinates.h>
 #include <casacore/measures/Measures/Stokes.h>
 #include <QDebug>
-// #include "UtilCASA.h"
 #include "CartaLib/UtilCASA.h"
 
 #ifdef DONT_COMPILE

--- a/carta/cpp/plugins/CasaImageLoader/CasaImageLoader.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CasaImageLoader.cpp
@@ -3,7 +3,6 @@
 #include "CartaLib/Hooks/Initialize.h"
 #include "CartaLib/Hooks/LoadAstroImage.h"
 #include <QDebug>
-#include <QPainter>
 #include <QTime>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/images/Images/FITSImage.h>

--- a/carta/cpp/plugins/CasaImageLoader/CasaImageLoader.pro
+++ b/carta/cpp/plugins/CasaImageLoader/CasaImageLoader.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin
@@ -35,7 +35,6 @@ LIBS += -L$$OUT_PWD/../../CartaLib/ -lCartaLib
 INCLUDEPATH += $${CASACOREDIR}/include
 INCLUDEPATH += $${WCSLIBDIR}/include
 INCLUDEPATH += $${CFITSIODIR}/include
-#INCLUDEPATH += $$PWD/../../core
 DEPENDPATH += $$PWD/../../core
 
 OTHER_FILES += \

--- a/carta/cpp/plugins/Colormaps1/Colormaps1.pro
+++ b/carta/cpp/plugins/Colormaps1/Colormaps1.pro
@@ -5,7 +5,7 @@
 #INCLUDEPATH += $$PROJECT_ROOT
 #DEPENDPATH += $$PROJECT_ROOT
 
-QT       += core gui
+QT       += core
 
 TARGET = plugin
 TEMPLATE = lib

--- a/carta/cpp/plugins/ConversionIntensity/ConversionIntensity.pro
+++ b/carta/cpp/plugins/ConversionIntensity/ConversionIntensity.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin

--- a/carta/cpp/plugins/ConversionSpectral/ConversionSpectral.pro
+++ b/carta/cpp/plugins/ConversionSpectral/ConversionSpectral.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin

--- a/carta/cpp/plugins/CyberSKA/CyberSKA.pro
+++ b/carta/cpp/plugins/CyberSKA/CyberSKA.pro
@@ -5,7 +5,7 @@
 INCLUDEPATH += $$PROJECT_ROOT
 DEPENDPATH += $$PROJECT_ROOT
 
-QT       += core gui network
+QT       += core network
 
 TARGET = plugin
 TEMPLATE = lib

--- a/carta/cpp/plugins/DevIntegration/DevIntegration.pro
+++ b/carta/cpp/plugins/DevIntegration/DevIntegration.pro
@@ -5,7 +5,7 @@
 INCLUDEPATH += $$PROJECT_ROOT
 DEPENDPATH += $$PROJECT_ROOT
 
-QT       += core gui
+QT       += core
 
 TARGET = plugin
 TEMPLATE = lib

--- a/carta/cpp/plugins/Fitter1D/Fitter1D.pro
+++ b/carta/cpp/plugins/Fitter1D/Fitter1D.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin

--- a/carta/cpp/plugins/Fitter1D/Gaussian1dFitService.cpp
+++ b/carta/cpp/plugins/Fitter1D/Gaussian1dFitService.cpp
@@ -1,10 +1,3 @@
-//#include "common.h"
-
-//#include "FitsParser.h"
-//#include "RaiCache.h"
-//#include "Optimization/LMGaussFitter1d.h"
-//#include "Optimization/LBTAGauss1dFitter.h"
-//#include "Optimization/HeuristicGauss1dFitter.h"
 #include "Gaussian1dFitService.h"
 #include "HeuristicGauss1dFitter.h"
 #include "LBTAGauss1dFitter.h"

--- a/carta/cpp/plugins/Fitter1D/Gaussian1dFitService.h
+++ b/carta/cpp/plugins/Fitter1D/Gaussian1dFitService.h
@@ -4,7 +4,6 @@
 #include <QObject>
 #include <QVector>
 #include <QThread>
-#include <QImage>
 #include <QTextStream>
 
 #include <stdexcept>

--- a/carta/cpp/plugins/Histogram/Histogram.pro
+++ b/carta/cpp/plugins/Histogram/Histogram.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 
 TARGET = plugin
 TEMPLATE = lib

--- a/carta/cpp/plugins/Histogram/ImageHistogram.cpp
+++ b/carta/cpp/plugins/Histogram/ImageHistogram.cpp
@@ -339,9 +339,9 @@ QString ImageHistogram<T>::getUnitsY() const {
 }
 
 template <class T>
-pair<float,float> ImageHistogram<T>::getDataRange() const {
+std::pair<float,float> ImageHistogram<T>::getDataRange() const {
     int count = m_xValues.size();
-    pair<float,float> range;
+    std::pair<float,float> range;
     if ( count >= 1 ){
         double minValue = m_xValues[0];
         double maxValue = m_xValues[0];

--- a/carta/cpp/plugins/ImageStatistics/ImageStatistics.pro
+++ b/carta/cpp/plugins/ImageStatistics/ImageStatistics.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin

--- a/carta/cpp/plugins/PCacheLevelDB/PCacheLevelDB.pro
+++ b/carta/cpp/plugins/PCacheLevelDB/PCacheLevelDB.pro
@@ -5,7 +5,7 @@
 INCLUDEPATH += $$PROJECT_ROOT
 DEPENDPATH += $$PROJECT_ROOT
 
-QT       += core gui
+QT       += core
 
 TARGET = plugin
 TEMPLATE = lib

--- a/carta/cpp/plugins/PCacheSqlite3/PCacheSqlite3.pro
+++ b/carta/cpp/plugins/PCacheSqlite3/PCacheSqlite3.pro
@@ -5,7 +5,7 @@
 INCLUDEPATH += $$PROJECT_ROOT
 DEPENDPATH += $$PROJECT_ROOT
 
-QT       += core gui sql
+QT       += core sql
 
 TARGET = plugin
 TEMPLATE = lib

--- a/carta/cpp/plugins/PercentileHistogram/PercentileHistogram.pro
+++ b/carta/cpp/plugins/PercentileHistogram/PercentileHistogram.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin

--- a/carta/cpp/plugins/PercentileManku99/PercentileManku99.pro
+++ b/carta/cpp/plugins/PercentileManku99/PercentileManku99.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin

--- a/carta/cpp/plugins/ProfileCASA/ProfileCASA.pro
+++ b/carta/cpp/plugins/ProfileCASA/ProfileCASA.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin

--- a/carta/cpp/plugins/RegionCASA/RegionCASA.pro
+++ b/carta/cpp/plugins/RegionCASA/RegionCASA.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT       += core gui
+QT       += core
 TARGET = plugin
 TEMPLATE = lib
 CONFIG += plugin

--- a/carta/cpp/plugins/plugins.pro
+++ b/carta/cpp/plugins/plugins.pro
@@ -3,28 +3,28 @@ TEMPLATE = subdirs
 
 SUBDIRS += casaCore
 SUBDIRS += CasaImageLoader
-SUBDIRS += Colormaps1
+#SUBDIRS += Colormaps1
 SUBDIRS += Fitter1D
 SUBDIRS += Histogram
 #SUBDIRS += WcsPlotter    # remove the Ast dependency as well
-SUBDIRS += ConversionSpectral
-SUBDIRS += ConversionSpectral/Test.pro
-SUBDIRS += ConversionIntensity
-SUBDIRS += ConversionIntensity/Test.pro
+#SUBDIRS += ConversionSpectral
+#SUBDIRS += ConversionSpectral/Test.pro
+#SUBDIRS += ConversionIntensity
+#SUBDIRS += ConversionIntensity/Test.pro
 SUBDIRS += ImageAnalysis
-SUBDIRS += ImageStatistics
+#SUBDIRS += ImageStatistics
 SUBDIRS += RegionCASA
-SUBDIRS += RegionDs9
+#SUBDIRS += RegionDs9
 SUBDIRS += ProfileCASA
-SUBDIRS += qimage
+#SUBDIRS += qimage
 #SUBDIRS += python273
 SUBDIRS += CyberSKA
 SUBDIRS += DevIntegration
 SUBDIRS += PCacheSqlite3
-SUBDIRS += PercentileHistogram
-SUBDIRS += PercentileHistogram/Test.pro
-SUBDIRS += PercentileManku99
-SUBDIRS += PercentileManku99/Test.pro
+#SUBDIRS += PercentileHistogram
+#SUBDIRS += PercentileHistogram/Test.pro
+#SUBDIRS += PercentileManku99
+#SUBDIRS += PercentileManku99/Test.pro
 
 unix:macx {
 # Disable PCacheLevelDB plugin on Mac, since build carta error with LevelDB enabled.

--- a/carta/cpp/plugins/qimage/qimage.pro
+++ b/carta/cpp/plugins/qimage/qimage.pro
@@ -5,7 +5,7 @@
 INCLUDEPATH += $$PROJECT_ROOT
 DEPENDPATH += $$PROJECT_ROOT
 
-QT       += core gui
+QT       += core
 LIBS += -L$$OUT_PWD/../../CartaLib/ -lCartaLib
 
 TARGET = plugin


### PR DESCRIPTION
Qt for X11 needs Qt GUI and Qt Widgets. In a back end service we do not need GUI or Widgets library. The changes are to remove dependence of "Qt += gui" or "Qt+= widgets" and the related library. Every commit is tested well. The <QApplication> is replaced by <QCoreApplication> which is the non-gui version of  <QApplication>. The carta core still has many library which depends on qt gui lib, a further refactoring is needed if the libs will be used.