### PR TITLE
Replace the uWebSocket by QWebSocket

### DIFF
--- a/carta/cpp/core/IConnector.h
+++ b/carta/cpp/core/IConnector.h
@@ -111,25 +111,25 @@ public:
     const size_t EVENT_NAME_LENGTH = 32;
     const size_t EVENT_ID_LENGTH = 4;
 
-    std::vector<char> serializeToArray(QString respName, uint32_t eventId, PBMSharedPtr msg, bool &success, size_t &requiredSize) {
-        success = false;
-        std::vector<char> result;
-        size_t messageLength = msg->ByteSize();
-        requiredSize = EVENT_NAME_LENGTH + EVENT_ID_LENGTH + messageLength;
-        if (result.size() < requiredSize) {
-            result.resize(requiredSize);
-        }
-        memset(result.data(), 0, EVENT_NAME_LENGTH);
-        memcpy(result.data(), respName.toStdString().c_str(), std::min<size_t>(respName.length(), EVENT_NAME_LENGTH));
-        memcpy(result.data() + EVENT_NAME_LENGTH, &eventId, EVENT_ID_LENGTH);
-        if (msg) {
-            msg->SerializeToArray(result.data() + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, messageLength);
-            success = true;
-            //emit jsBinaryMessageResultSignal(result.data(), requiredSize);
-            //qDebug() << "Send event:" << respName << QTime::currentTime().toString();
-        }
-        return result;
-    }
+//    std::vector<char> serializeToArray(QString respName, uint32_t eventId, PBMSharedPtr msg, bool &success, size_t &requiredSize) {
+//        success = false;
+//        std::vector<char> result;
+//        size_t messageLength = msg->ByteSize();
+//        requiredSize = EVENT_NAME_LENGTH + EVENT_ID_LENGTH + messageLength;
+//        if (result.size() < requiredSize) {
+//            result.resize(requiredSize);
+//        }
+//        memset(result.data(), 0, EVENT_NAME_LENGTH);
+//        memcpy(result.data(), respName.toStdString().c_str(), std::min<size_t>(respName.length(), EVENT_NAME_LENGTH));
+//        memcpy(result.data() + EVENT_NAME_LENGTH, &eventId, EVENT_ID_LENGTH);
+//        if (msg) {
+//            msg->SerializeToArray(result.data() + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, messageLength);
+//            success = true;
+//            //emit jsBinaryMessageResultSignal(result.data(), requiredSize);
+//            //qDebug() << "Send event:" << respName << QTime::currentTime().toString();
+//        }
+//        return result;
+//    }
 
     virtual ~IConnector() {}
 };

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -299,17 +299,6 @@ void NewServerConnector::onBinaryMessageSignalSlot(const char *message, size_t l
         qFatal("Illegal request in NewServerConnector. Please handle it in SessionDispatcher.");
         return;
 
-    } else if (eventName == "FILE_INFO_REQUEST") {
-        Carta::State::ObjectManager* objMan = Carta::State::ObjectManager::objectManager();
-        Carta::Data::DataLoader *dataLoader = objMan->createObject<Carta::Data::DataLoader>();
-
-        CARTA::FileInfoRequest fileInfoRequest;
-        fileInfoRequest.ParseFromArray(message + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, length - EVENT_NAME_LENGTH - EVENT_ID_LENGTH);
-        msg = dataLoader->getFileInfo(fileInfoRequest);
-
-        // send the serialized message to the frontend
-        sendSerializedMessage("FILE_INFO_RESPONSE", eventId, msg);
-        return;
     } else if (eventName == "CLOSE_FILE") {
 
         CARTA::CloseFile closeFile;
@@ -343,13 +332,23 @@ void NewServerConnector::onBinaryMessageSignalSlot(const char *message, size_t l
 }
 
 void NewServerConnector::fileListRequestSignalSlot(uint32_t eventId, CARTA::FileListRequest fileListRequest) {
-    // get the DataLoader
+    // get DataLoader obj
     Carta::State::ObjectManager* objMan = Carta::State::ObjectManager::objectManager();
     Carta::Data::DataLoader *dataLoader = objMan->createObject<Carta::Data::DataLoader>();
     PBMSharedPtr msg = dataLoader->getFileList(fileListRequest);
 
     // send the serialized message to the frontend
     sendSerializedMessage("FILE_LIST_RESPONSE", eventId, msg);
+}
+
+void NewServerConnector::fileInfoRequestSignalSlot(uint32_t eventId, CARTA::FileInfoRequest fileInfoRequest) {
+    // get DataLoader obj
+    Carta::State::ObjectManager* objMan = Carta::State::ObjectManager::objectManager();
+    Carta::Data::DataLoader *dataLoader = objMan->createObject<Carta::Data::DataLoader>();
+    PBMSharedPtr msg = dataLoader->getFileInfo(fileInfoRequest);
+
+    // send the serialized message to the frontend
+    sendSerializedMessage("FILE_INFO_RESPONSE", eventId, msg);
 }
 
 void NewServerConnector::openFileSignalSlot(uint32_t eventId, QString fileDir, QString fileName, int fileId, int regionId) {

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -299,20 +299,6 @@ void NewServerConnector::onBinaryMessageSignalSlot(const char *message, size_t l
         qFatal("Illegal request in NewServerConnector. Please handle it in SessionDispatcher.");
         return;
 
-    } else if (eventName == "FILE_LIST_REQUEST") {
-        respName = "FILE_LIST_RESPONSE";
-
-        Carta::State::ObjectManager* objMan = Carta::State::ObjectManager::objectManager();
-        Carta::Data::DataLoader *dataLoader = objMan->createObject<Carta::Data::DataLoader>();
-
-        CARTA::FileListRequest fileListRequest;
-        fileListRequest.ParseFromArray(message + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, length - EVENT_NAME_LENGTH - EVENT_ID_LENGTH);
-        msg = dataLoader->getFileList(fileListRequest);
-
-        // send the serialized message to the frontend
-        sendSerializedMessage(respName, eventId, msg);
-        return;
-
     } else if (eventName == "FILE_INFO_REQUEST") {
         Carta::State::ObjectManager* objMan = Carta::State::ObjectManager::objectManager();
         Carta::Data::DataLoader *dataLoader = objMan->createObject<Carta::Data::DataLoader>();
@@ -354,6 +340,16 @@ void NewServerConnector::onBinaryMessageSignalSlot(const char *message, size_t l
     // socket->send(binaryPayloadCache.data(), requiredSize, uWS::BINARY);
     // emit jsTextMessageResultSignal(result);
     return;
+}
+
+void NewServerConnector::fileListRequestSignalSlot(uint32_t eventId, CARTA::FileListRequest fileListRequest) {
+    // get the DataLoader
+    Carta::State::ObjectManager* objMan = Carta::State::ObjectManager::objectManager();
+    Carta::Data::DataLoader *dataLoader = objMan->createObject<Carta::Data::DataLoader>();
+    PBMSharedPtr msg = dataLoader->getFileList(fileListRequest);
+
+    // send the serialized message to the frontend
+    sendSerializedMessage("FILE_LIST_RESPONSE", eventId, msg);
 }
 
 void NewServerConnector::openFileSignalSlot(uint32_t eventId, QString fileDir, QString fileName, int fileId, int regionId) {

--- a/carta/cpp/desktop/NewServerConnector.cpp
+++ b/carta/cpp/desktop/NewServerConnector.cpp
@@ -272,7 +272,7 @@ void NewServerConnector::onTextMessage(QString message){
     emit jsTextMessageResultSignal(result);
 }
 
-void NewServerConnector::onBinaryMessageSignalSlot(char* message, size_t length){
+void NewServerConnector::onBinaryMessageSignalSlot(const char *message, size_t length){
     if (length < EVENT_NAME_LENGTH + EVENT_ID_LENGTH){
         qFatal("Illegal message.");
         return;

--- a/carta/cpp/desktop/NewServerConnector.h
+++ b/carta/cpp/desktop/NewServerConnector.h
@@ -77,7 +77,7 @@ public slots:
 
     void startViewerSlot(const QString & sessionID);
     void onTextMessage(QString message);
-    void onBinaryMessageSignalSlot(char* message, size_t length);
+    void onBinaryMessageSignalSlot(const char* message, size_t length);
     void sendSerializedMessage(QString respName, uint32_t eventId, PBMSharedPtr msg);
 
     void imageChannelUpdateSignalSlot(uint32_t eventId, int fileId, int channel, int stoke);
@@ -93,7 +93,7 @@ signals:
     //new arch
     void startViewerSignal(const QString & sessionID);
     void onTextMessageSignal(QString message);
-    void onBinaryMessageSignal(char* message, size_t length);
+    void onBinaryMessageSignal(const char* message, size_t length);
 
     void jsTextMessageResultSignal(QString result);
     void jsBinaryMessageResultSignal(QString respName, uint32_t eventId, PBMSharedPtr message);

--- a/carta/cpp/desktop/NewServerConnector.h
+++ b/carta/cpp/desktop/NewServerConnector.h
@@ -87,6 +87,7 @@ public slots:
     void setCursorSignalSlot(uint32_t eventId, int fileId, CARTA::Point point, CARTA::SetSpatialRequirements setSpatialReqs);
 
     void fileListRequestSignalSlot(uint32_t eventId, CARTA::FileListRequest fileListRequest);
+    void fileInfoRequestSignalSlot(uint32_t eventId, CARTA::FileInfoRequest fileInfoRequest);
 
 signals:
 
@@ -107,6 +108,7 @@ signals:
     void setCursorSignal(uint32_t eventId, int fileId, CARTA::Point point, CARTA::SetSpatialRequirements setSpatialReqs);
 
     void fileListRequestSignal(uint32_t eventId, CARTA::FileListRequest fileListRequest);
+    void fileInfoRequestSignal(uint32_t eventId, CARTA::FileInfoRequest fileInfoRequest);
 
     // /// we emit this signal when state is changed (either by c++ or by javascript)
     // /// we listen to this signal, and so does javascript

--- a/carta/cpp/desktop/NewServerConnector.h
+++ b/carta/cpp/desktop/NewServerConnector.h
@@ -86,6 +86,8 @@ public slots:
     void openFileSignalSlot(uint32_t eventId, QString fileDir, QString fileName, int fileId, int regionId);
     void setCursorSignalSlot(uint32_t eventId, int fileId, CARTA::Point point, CARTA::SetSpatialRequirements setSpatialReqs);
 
+    void fileListRequestSignalSlot(uint32_t eventId, CARTA::FileListRequest fileListRequest);
+
 signals:
 
     //grimmer: newArch will not use stateChange mechanism anymore
@@ -103,6 +105,8 @@ signals:
                             bool isZFP, int precision, int numSubsets);
     void openFileSignal(uint32_t eventId, QString fileDir, QString fileName, int fileId, int regionId);
     void setCursorSignal(uint32_t eventId, int fileId, CARTA::Point point, CARTA::SetSpatialRequirements setSpatialReqs);
+
+    void fileListRequestSignal(uint32_t eventId, CARTA::FileListRequest fileListRequest);
 
     // /// we emit this signal when state is changed (either by c++ or by javascript)
     // /// we listen to this signal, and so does javascript

--- a/carta/cpp/desktop/SessionDispatcher.cpp
+++ b/carta/cpp/desktop/SessionDispatcher.cpp
@@ -151,8 +151,8 @@ void SessionDispatcher::onBinaryMessage(QByteArray qByteMessage) {
                     connector, SLOT(startViewerSlot(const QString &)));
 
             // general commands
-            connect(connector, SIGNAL(onBinaryMessageSignal(const char*, size_t)),
-                    connector, SLOT(onBinaryMessageSignalSlot(const char*, size_t)));
+            //connect(connector, SIGNAL(onBinaryMessageSignal(const char*, size_t)),
+            //        connector, SLOT(onBinaryMessageSignalSlot(const char*, size_t)));
 
             // file list request
             connect(connector, SIGNAL(fileListRequestSignal(uint32_t, CARTA::FileListRequest)),
@@ -304,7 +304,8 @@ void SessionDispatcher::onBinaryMessage(QByteArray qByteMessage) {
             emit connector->setCursorSignal(eventId, fileId, point, spatialReqs);
 
         } else {
-            emit connector->onBinaryMessageSignal(message, length);
+            qCritical() << "[SessionDispatcher] There is no event handler:" << eventName;
+            //emit connector->onBinaryMessageSignal(message, length);
         }
     }
 }

--- a/carta/cpp/desktop/SessionDispatcher.cpp
+++ b/carta/cpp/desktop/SessionDispatcher.cpp
@@ -144,6 +144,7 @@ void SessionDispatcher::onBinaryMessage(QByteArray qByteMessage) {
             qRegisterMetaType<CARTA::Point>("CARTA::Point");
             qRegisterMetaType<CARTA::SetSpatialRequirements>("CARTA::SetSpatialRequirements");
             qRegisterMetaType<CARTA::FileListRequest>("CARTA::FileListRequest");
+            qRegisterMetaType<CARTA::FileInfoRequest>("CARTA::FileInfoRequest");
 
             // start the image viewer
             connect(connector, SIGNAL(startViewerSignal(const QString &)),
@@ -156,6 +157,10 @@ void SessionDispatcher::onBinaryMessage(QByteArray qByteMessage) {
             // file list request
             connect(connector, SIGNAL(fileListRequestSignal(uint32_t, CARTA::FileListRequest)),
                     connector, SLOT(fileListRequestSignalSlot(uint32_t, CARTA::FileListRequest)));
+
+            // file info request
+            connect(connector, SIGNAL(fileInfoRequestSignal(uint32_t, CARTA::FileInfoRequest)),
+                    connector, SLOT(fileInfoRequestSignalSlot(uint32_t, CARTA::FileInfoRequest)));
 
             // open file
             connect(connector, SIGNAL(openFileSignal(uint32_t, QString, QString, int, int)),
@@ -240,6 +245,12 @@ void SessionDispatcher::onBinaryMessage(QByteArray qByteMessage) {
             CARTA::FileListRequest fileListRequest;
             fileListRequest.ParseFromArray(message + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, length - EVENT_NAME_LENGTH - EVENT_ID_LENGTH);
             emit connector->fileListRequestSignal(eventId, fileListRequest);
+
+        } else if (eventName == "FILE_INFO_REQUEST") {
+
+            CARTA::FileInfoRequest fileInfoRequest;
+            fileInfoRequest.ParseFromArray(message + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, length - EVENT_NAME_LENGTH - EVENT_ID_LENGTH);
+            emit connector->fileInfoRequestSignal(eventId, fileInfoRequest);
 
         } else if (eventName == "OPEN_FILE") {
 

--- a/carta/cpp/desktop/SessionDispatcher.cpp
+++ b/carta/cpp/desktop/SessionDispatcher.cpp
@@ -45,7 +45,7 @@ void SessionDispatcher::startWebSocket(){
         qDebug() << "SessionDispatcher listening on port" << port;
     }
 
-    if (!m_hub.listen(port)){
+    /*if (!m_hub.listen(port)){
         qFatal("Failed to open web socket server.");
         return;
     }
@@ -64,17 +64,17 @@ void SessionDispatcher::startWebSocket(){
     });
 
     // repeat calling non-blocking poll() in qt event loop
-    loopPoll();
+    loopPoll();*/
 }
 
-void SessionDispatcher::loopPoll(){
+/*void SessionDispatcher::loopPoll(){
     m_hub.poll();
     // submit a queue into qt eventloop
     defer([this](){
         QThread::msleep(10); // sleep for 10 ms in order to ease the loading of CPU
         loopPoll();
     });
-}
+}*/
 
 SessionDispatcher::SessionDispatcher() {
 
@@ -83,7 +83,7 @@ SessionDispatcher::SessionDispatcher() {
 SessionDispatcher::~SessionDispatcher() {
 
 }
-
+/*
 void SessionDispatcher::onNewConnection(uWS::WebSocket<uWS::SERVER> *socket) {
     qDebug() << "A new connection!!";
 }
@@ -330,7 +330,7 @@ void SessionDispatcher::forwardBinaryMessageResult(QString respName, uint32_t ev
         qDebug() << "[SessionDispatcher] ERROR! Cannot find the corresponding websocket!";
     }
 }
-
+*/
 IConnector* SessionDispatcher::getConnectorInMap(const QString & sessionID) {
     mutex.lock();
     auto iter = clientList.find(sessionID);

--- a/carta/cpp/desktop/SessionDispatcher.cpp
+++ b/carta/cpp/desktop/SessionDispatcher.cpp
@@ -143,6 +143,7 @@ void SessionDispatcher::onBinaryMessage(QByteArray qByteMessage) {
             qRegisterMetaType<PBMSharedPtr>("PBMSharedPtr");
             qRegisterMetaType<CARTA::Point>("CARTA::Point");
             qRegisterMetaType<CARTA::SetSpatialRequirements>("CARTA::SetSpatialRequirements");
+            qRegisterMetaType<CARTA::FileListRequest>("CARTA::FileListRequest");
 
             // start the image viewer
             connect(connector, SIGNAL(startViewerSignal(const QString &)),
@@ -151,6 +152,10 @@ void SessionDispatcher::onBinaryMessage(QByteArray qByteMessage) {
             // general commands
             connect(connector, SIGNAL(onBinaryMessageSignal(const char*, size_t)),
                     connector, SLOT(onBinaryMessageSignalSlot(const char*, size_t)));
+
+            // file list request
+            connect(connector, SIGNAL(fileListRequestSignal(uint32_t, CARTA::FileListRequest)),
+                    connector, SLOT(fileListRequestSignalSlot(uint32_t, CARTA::FileListRequest)));
 
             // open file
             connect(connector, SIGNAL(openFileSignal(uint32_t, QString, QString, int, int)),
@@ -230,7 +235,13 @@ void SessionDispatcher::onBinaryMessage(QByteArray qByteMessage) {
     }
 
     if (connector != nullptr) {
-        if (eventName == "OPEN_FILE") {
+        if (eventName == "FILE_LIST_REQUEST") {
+
+            CARTA::FileListRequest fileListRequest;
+            fileListRequest.ParseFromArray(message + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, length - EVENT_NAME_LENGTH - EVENT_ID_LENGTH);
+            emit connector->fileListRequestSignal(eventId, fileListRequest);
+
+        } else if (eventName == "OPEN_FILE") {
 
             CARTA::OpenFile openFile;
             openFile.ParseFromArray(message + EVENT_NAME_LENGTH + EVENT_ID_LENGTH, length - EVENT_NAME_LENGTH - EVENT_ID_LENGTH);

--- a/carta/cpp/desktop/SessionDispatcher.cpp
+++ b/carta/cpp/desktop/SessionDispatcher.cpp
@@ -17,9 +17,9 @@
 #include <QStringList>
 
 #include <thread>
-// #include "websocketclientwrapper.h"
-// #include "websockettransport.h"
-// #include "qwebchannel.h"
+//#include "websocketclientwrapper.h"
+//#include "websockettransport.h"
+//#include "qwebchannel.h"
 #include <QBuffer>
 #include <QThread>
 #include <QUuid>
@@ -44,6 +44,15 @@ void SessionDispatcher::startWebSocket(){
     else {
         qDebug() << "SessionDispatcher listening on port" << port;
     }
+
+    m_pWebSocketServer = new QWebSocketServer(QStringLiteral("New QWebServer start"), QWebSocketServer::NonSecureMode, this);
+
+    if (!m_pWebSocketServer->listen(QHostAddress::Any, port)) {
+        qFatal("Failed to open web socket server.");
+        return;
+    }
+
+    connect(m_pWebSocketServer, &QWebSocketServer::newConnection, this, &SessionDispatcher::onNewConnection);
 
     /*if (!m_hub.listen(port)){
         qFatal("Failed to open web socket server.");
@@ -83,6 +92,13 @@ SessionDispatcher::SessionDispatcher() {
 SessionDispatcher::~SessionDispatcher() {
 
 }
+
+void SessionDispatcher::onNewConnection() {
+    QWebSocket* socket = m_pWebSocketServer->nextPendingConnection();
+    //connect(socket, &QWebSocket::textMessageReceived, this, &SessionDispatcher::onTextMessage);
+    //connect(socket, &QWebSocket::binaryMessageReceived, this, &SessionDispatcher::onBinaryMessage);
+}
+
 /*
 void SessionDispatcher::onNewConnection(uWS::WebSocket<uWS::SERVER> *socket) {
     qDebug() << "A new connection!!";

--- a/carta/cpp/desktop/SessionDispatcher.h
+++ b/carta/cpp/desktop/SessionDispatcher.h
@@ -67,6 +67,8 @@ private:
     // prevent being accessed by other to avoid thread-safety problem
     std::map<QWebSocket*, NewServerConnector*> sessionList;
 
+    std::vector<char> _serializeToArray(QString respName, uint32_t eventId, PBMSharedPtr msg, bool &success, size_t &requiredSize);
+
 private slots:
 
     void onNewConnection();

--- a/carta/cpp/desktop/SessionDispatcher.h
+++ b/carta/cpp/desktop/SessionDispatcher.h
@@ -64,12 +64,19 @@ protected:
 private:
 
     QMutex mutex;
+    QWebSocketServer *m_pWebSocketServer;
     // prevent being accessed by other to avoid thread-safety problem
+    std::map<QWebSocket*, NewServerConnector*> sessionList;
+
 //    uWS::Hub m_hub;
 //    std::map<uWS::WebSocket<uWS::SERVER>*, NewServerConnector*> sessionList;
 //    void loopPoll();
 
 private slots:
+
+    void onNewConnection();
+    //void onTextMessage(QString);
+    //void onBinaryMessage(QByteArray);
 /*
     void onNewConnection(uWS::WebSocket<uWS::SERVER> *ws);
     void onTextMessage(uWS::WebSocket<uWS::SERVER> *ws, char* message, size_t length);

--- a/carta/cpp/desktop/SessionDispatcher.h
+++ b/carta/cpp/desktop/SessionDispatcher.h
@@ -8,7 +8,7 @@
 
 #include <QObject>
 #include <qmutex.h>
-#include <uWS/uWS.h>
+//#include <uWS/uWS.h>
 #include "NewServerConnector.h"
 
 #include "core/IConnector.h"
@@ -65,18 +65,18 @@ private:
 
     QMutex mutex;
     // prevent being accessed by other to avoid thread-safety problem
-    uWS::Hub m_hub;
-    std::map<uWS::WebSocket<uWS::SERVER>*, NewServerConnector*> sessionList;
-    void loopPoll();
+//    uWS::Hub m_hub;
+//    std::map<uWS::WebSocket<uWS::SERVER>*, NewServerConnector*> sessionList;
+//    void loopPoll();
 
 private slots:
-
+/*
     void onNewConnection(uWS::WebSocket<uWS::SERVER> *ws);
     void onTextMessage(uWS::WebSocket<uWS::SERVER> *ws, char* message, size_t length);
     void onBinaryMessage(uWS::WebSocket<uWS::SERVER> *ws, char* message, size_t length);
     void forwardTextMessageResult(QString);
     void forwardBinaryMessageResult(QString respName, uint32_t eventId, PBMSharedPtr protoMsg);
-
+*/
 };
 
 

--- a/carta/cpp/desktop/SessionDispatcher.h
+++ b/carta/cpp/desktop/SessionDispatcher.h
@@ -75,8 +75,8 @@ private:
 private slots:
 
     void onNewConnection();
-    //void onTextMessage(QString);
-    //void onBinaryMessage(QByteArray);
+    void onTextMessage(QString);
+    void onBinaryMessage(QByteArray qByteMessage);
 /*
     void onNewConnection(uWS::WebSocket<uWS::SERVER> *ws);
     void onTextMessage(uWS::WebSocket<uWS::SERVER> *ws, char* message, size_t length);

--- a/carta/cpp/desktop/SessionDispatcher.h
+++ b/carta/cpp/desktop/SessionDispatcher.h
@@ -8,7 +8,6 @@
 
 #include <QObject>
 #include <qmutex.h>
-//#include <uWS/uWS.h>
 #include "NewServerConnector.h"
 
 #include "core/IConnector.h"
@@ -68,22 +67,13 @@ private:
     // prevent being accessed by other to avoid thread-safety problem
     std::map<QWebSocket*, NewServerConnector*> sessionList;
 
-//    uWS::Hub m_hub;
-//    std::map<uWS::WebSocket<uWS::SERVER>*, NewServerConnector*> sessionList;
-//    void loopPoll();
-
 private slots:
 
     void onNewConnection();
     void onTextMessage(QString);
     void onBinaryMessage(QByteArray qByteMessage);
-/*
-    void onNewConnection(uWS::WebSocket<uWS::SERVER> *ws);
-    void onTextMessage(uWS::WebSocket<uWS::SERVER> *ws, char* message, size_t length);
-    void onBinaryMessage(uWS::WebSocket<uWS::SERVER> *ws, char* message, size_t length);
     void forwardTextMessageResult(QString);
     void forwardBinaryMessageResult(QString respName, uint32_t eventId, PBMSharedPtr protoMsg);
-*/
 };
 
 

--- a/carta/cpp/desktop/desktop.pro
+++ b/carta/cpp/desktop/desktop.pro
@@ -2,7 +2,7 @@
   error( "Could not find the common.pri file!" )
 }
 
-QT  +=  core xml
+QT  +=  core xml websockets webchannel network
 QT  -=  gui widgets
 
 HEADERS += \
@@ -17,20 +17,28 @@ SOURCES += \
     NewServerConnector.cpp \
     SessionDispatcher.cpp
 
+HEADERS += \
+    websockettransport.h \
+    websocketclientwrapper.h
+
+SOURCES += \
+    websockettransport.cpp \
+    websocketclientwrapper.cpp
+
 INCLUDEPATH += ../../../ThirdParty/rapidjson/include
 INCLUDEPATH += ../core
 
 INCLUDEPATH += ../../../ThirdParty/protobuf/include
 LIBS += -L../../../ThirdParty/protobuf/lib -lprotobuf
 
-INCLUDEPATH += /usr/local/opt/openssl/include
-LIBS += -L/usr/local/opt/openssl/lib -lssl
+#INCLUDEPATH += /usr/local/opt/openssl/include
+#LIBS += -L/usr/local/opt/openssl/lib -lssl
 
-INCLUDEPATH += /usr/local/opt/libuv/include
-LIBS += -L/usr/local/opt/libuv/lib -luv
+#INCLUDEPATH += /usr/local/opt/libuv/include
+#LIBS += -L/usr/local/opt/libuv/lib -luv
 
-INCLUDEPATH += ../../../ThirdParty/uWebSockets/include
-LIBS += -L../../../ThirdParty/uWebSockets/lib -luWS -lz -lssl
+#INCLUDEPATH += ../../../ThirdParty/uWebSockets/include
+#LIBS += -L../../../ThirdParty/uWebSockets/lib -luWS -lz -lssl
 
 unix: LIBS += -L$$OUT_PWD/../core/ -lcore
 unix: LIBS += -L$$OUT_PWD/../CartaLib/ -lCartaLib


### PR DESCRIPTION
Replace the uWebSocket by QWebSocket in order to avoid the deadlocks of two event loops (uWebSocket and Qt).